### PR TITLE
Make minecraft:planks Ore Dictionary'ed

### DIFF
--- a/src/main/resources/craftingmappings.json
+++ b/src/main/resources/craftingmappings.json
@@ -168,7 +168,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 6
         }
       ]
@@ -194,7 +194,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 6
         }
       ]
@@ -220,7 +220,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 1
         }
       ]
@@ -1191,7 +1191,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 8
         }
       ]
@@ -1280,7 +1280,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 3
         }
       ]
@@ -2734,7 +2734,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 1
         }
       ]
@@ -2750,7 +2750,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 2
         }
       ]
@@ -3260,7 +3260,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 1
         }
       ]
@@ -3411,7 +3411,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 2
         }
       ]
@@ -3427,7 +3427,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 3
         }
       ]
@@ -3459,7 +3459,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 2
         }
       ]
@@ -3524,7 +3524,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 2
         }
       ]
@@ -3732,7 +3732,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 3
         }
       ]
@@ -3748,7 +3748,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 5
         }
       ]
@@ -3969,7 +3969,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 3
         }
       ]
@@ -4160,7 +4160,7 @@
         },
         {
           "entryName": "minecraft:planks",
-          "isOreDictionary": false,
+          "isOreDictionary": true,
           "count": 2
         }
       ]


### PR DESCRIPTION
Should make it so Oak planks aren't the only wood required.

