### PR TITLE
Add Prop Break Textures

### DIFF
--- a/src/main/resources/assets/mwc/models/item/barrier.json
+++ b/src/main/resources/assets/mwc/models/item/barrier.json
@@ -2,6 +2,7 @@
     "parent": "builtin/generated",
     "textures": {
         "layer0": "mwc:items/barrier"
+	"particle": "minecraft:block/obsidian"
     },
     "display": {
 		"thirdperson_righthand": {

--- a/src/main/resources/assets/mwc/models/item/barrier_rotated.json
+++ b/src/main/resources/assets/mwc/models/item/barrier_rotated.json
@@ -2,6 +2,7 @@
     "parent": "builtin/generated",
     "textures": {
         "layer0": "mwc:items/barrier_rotated"
+	"particle": "minecraft:block/obsidian"
     },
     "display": {
 		"thirdperson_righthand": {

--- a/src/main/resources/assets/mwc/models/item/sandbag.json
+++ b/src/main/resources/assets/mwc/models/item/sandbag.json
@@ -3,6 +3,7 @@
     "parent": "builtin/generated",
     "textures": {
         "layer0": "mwc:items/barrel"
+	"particle": "minecraft:block/sand"
     },
     "display": {
 		"thirdperson_righthand": {

--- a/src/main/resources/assets/mwc/models/item/sandbagwall.json
+++ b/src/main/resources/assets/mwc/models/item/sandbagwall.json
@@ -3,6 +3,7 @@
     "parent": "builtin/generated",
     "textures": {
         "layer0": "mwc:items/barrel"
+	"particle": "minecraft:block/obsidian"
     },
     "display": {
 		"thirdperson_righthand": {

--- a/src/main/resources/assets/mwc/models/item/sandbagwall.json
+++ b/src/main/resources/assets/mwc/models/item/sandbagwall.json
@@ -3,7 +3,7 @@
     "parent": "builtin/generated",
     "textures": {
         "layer0": "mwc:items/barrel"
-	"particle": "minecraft:block/obsidian"
+	"particle": "minecraft:block/sand"
     },
     "display": {
 		"thirdperson_righthand": {


### PR DESCRIPTION
## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [x] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [ ] 🌟 Quality Of Life
- [ ] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

When breaking any prop MWC shows the purple and black error texture. I have (hopefully) added block break effects to the barrier props and sandbag props. I only did these because I'm unsure if i did it correctly and these props and used often for deco on my server.

## 🧐 The Rationale

The props look bad if shot

## 🎯 Key Objectives

not break the props

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed

