### PR TITLE
Fix hitbox's & Make Airdrop not give loot.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -94,6 +94,13 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed 3rd person hovering weapons such as the MP7, CZ-805 Bren, and Python and Taurus revolvers
 - Fixed visual bugs for weapons like FN F2000 when aiming the gun, M4A1 with "M16 Stock", Malyuk with grip accessories, beowulf50Cal with m38 front sight, revolver related accessories and general bipod adjustments on weapons
 - Fixed the attachment of the Long Deagle
+- Fixed hitboxes not lining up with their models:
+  - Fridge open and closed
+  - Locker
+  - SCP Locker
+  - Dumpster
+  - Sandbag
+  - Duel Floodlight
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 
 ## Warning
 
-**If you are upgrading from either Vic's Modern Warfare or Modern Warfare Cubed Version 0.1-Dev-6 or under all Modern Warfare related item, blocks weapons etc... will disappear from your save either back up your world or start a new one.**
+**If you are upgrading from either Vic's Modern Warfare or Modern Warfare Cubed Version 0.1-Dev-6 or under all Modern Warfare related items, blocks weapons, etc... will disappear from your save either back up your world or start a new one.**
 
 ### Highlight
 
@@ -34,13 +34,13 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Translations for Chinese, Spanish, and Turkish languages
 - GitHub URL in `mcmod.info`
 - Proning in single player mode (**Note: Currently unanimated; player will appear standing**)
-- Shells life go increased 1606% no performance impact in extreme cases
+- Shells life increased by 1606% with no performance impact in extreme cases
 
 ### Changed
 
-- Overhauled textures of AAC Honey Badger, Beowulf, HK 417, M16A1, 100rnd 5.56x45mm NATO STANAG Drum Magazine and the pink camo skin
+- Overhauled textures of AAC Honey Badger, Beowulf, HK 417, M16A1, 100rnd 5.56x45mm NATO STANAG Drum Magazine, and the pink camo skin
 - Overhauled animations and sound effects of the M40A6 and Uzi
-- Overhauled the texture of the Leupold Scope, EOTech Holographic A65 Sight, Aim Point Comp M5 Sight, OKP-7 Sight, Bijia Reflex Sight, RMR Sight and Eotech Hybrid HHS™ II Sight
+- Overhauled the texture of the Leupold Scope, EOTech Holographic A65 Sight, Aim Point Comp M5 Sight, OKP-7 Sight, Bijia Reflex Sight, RMR Sight, and Eotech Hybrid HHS™ II Sight
 - Reworked the config system:
   - Old XML config has been removed, and all configs have been consolidated into a new JSON config. Issues with some non-functioning configs have been resolved
   - Adjusted craftingmappings.json to now only override recipes, rather than removing all recipes
@@ -76,7 +76,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 ### Fixed
 
 - Fixed entity generation issue (now modifying the entity's health and generation rate requires restarting the game)
-- Fixed Minecraft armor making you invulnerable to bullet (less realistic but they aren't anyway lol)
+- Fixed Minecraft armor making you invulnerable to bullets (less realistic but they aren't anyway lol)
 - Fixed issue with config for bullets breaking glass being ignored
 - Fixed bullet's being able to penetrate:
   - Glass
@@ -92,10 +92,10 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed turrets spawning without weapons
 - Fixed 7.62x54mm SVD magazine using 7.62x39mm bullets
 - Fixed 3rd person hovering weapons such as the MP7, CZ-805 Bren, and Python and Taurus revolvers
-- Fixed visual bugs for weapons like FN F2000 when aiming the gun, M4A1 with "M16 Stock", Malyuk with grip accessories, beowulf50Cal with m38 front sight, revolver related accessories and general bipod adjustments on weapons
+- Fixed visual bugs for weapons like FN F2000 when aiming the gun, M4A1 with "M16 Stock", Malyuk with grip accessories, beowulf50Cal with m38 front sight, revolver-related accessories, and general bipod adjustments on weapons
 - Fixed the attachment of the Long Deagle
-- Fixed hitboxes not lining up with their models:
-  - Fridge open and closed
+- Fixed prop hitboxes not lining up with their models:
+  - Fridge (open/closed)
   - Locker
   - SCP Locker
   - Dumpster
@@ -122,13 +122,13 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 
 - Switched to [Raven](https://github.com/eigenraven) amazing [RetroFuturaGradle](https://github.com/GTNewHorizons/RetroFuturaGradle)
 - Updated to Gradle 8.1.1
-- Cleaned-up on build.gradle & gradle.properties
-- Gradle now automatically updates version and id in `ModReference.java`
+- Cleaned up build.gradle & gradle.properties
+- Gradle now automatically updates the version and id in `ModReference.java`
 - Updated Forge version
 - Improved build times
 - Automatically mark some folders as excluded
 - Major Refactors
-- [WIP] Cleaned-up the codebase
+- [WIP] Cleaned up the codebase
 - [WIP] Renamed unintelligible variables to more readable names
 - Overhauled the internal process of item and block creation
 - Changed name and mod id

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,7 +34,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Translations for Chinese, Spanish, and Turkish languages
 - GitHub URL in `mcmod.info`
 - Proning in single player mode (**Note: Currently unanimated; player will appear standing**)
-- Shells life increased by 1606% with no performance impact in extreme cases
+- Shells life got increased to 1606 with no performance impact in extreme cases
 
 ### Changed
 

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -22,16 +22,16 @@ public class TileEntities {
 //        .withName("blank")
 //        .withModelClassName("com.paneedah.mwc.models.Black")
 //        .withTextureName("textures/models/bodybag.png")
-////        .withEquipementDispenseSound(sound)
+//        .withEquipementDispenseSound(sound)
 //        .withCreativeTab(MWC.PropsTab)
 //        .withPositioning(tileEntity -> {
 //            GL11.glScalef(0.9f, 0.9f, 0.9f);
 //            GL11.glTranslatef(0.5f, -0.9f, 0.55f);
 //            GL11.glRotatef(-90F, 0f, 1f, 0f);
 //        })
-////        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
-////        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
-////        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
+//        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
+//        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
+//        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
 //        .withEquipmentDispenseTimeout(10)
 //        .build(MWC.MOD_CONTEXT);
 

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -445,7 +445,7 @@ public class TileEntities {
         new LootBoxConfiguration()
         .withMaterial(Material.ROCK)
         .withName("office_chair")
-        .withModelClassName("com.paneedah.mwc.models.OfficeChair")
+        .withModelClassName("com.paneedah.mwc.models.OfficeChair2")
         .withTextureName("textures/models/officechair.png")
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
@@ -458,7 +458,7 @@ public class TileEntities {
         new LootBoxConfiguration()
         .withMaterial(Material.ROCK)
         .withName("office_chair_2")
-        .withModelClassName("com.paneedah.mwc.models.OfficeChair2")
+        .withModelClassName("com.paneedah.mwc.models.OfficeChair")
         .withTextureName("textures/models/officechair.png")
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
@@ -486,7 +486,6 @@ public class TileEntities {
         .withName("desk_corner_alt1")
         .withModelClassName("com.paneedah.mwc.models.DeskCornerAlt1")
         .withTextureName("textures/models/desk.png")
-//        .withEquipementDispenseSound(sound)
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
             GL11.glScalef(1.07f, 1f, 1f);

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -1163,6 +1163,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.VendingMachine")
         .withTextureName("textures/models/vendingmachine.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.8f, 0.8f, 0.8f);
             GL11.glTranslatef(0.55f, 0.4f, 0.62f);
@@ -1306,6 +1328,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.DuelFloodLight")
         .withTextureName("textures/models/duelfloodlight.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.8f, 0.8f, 0.8f);
             GL11.glTranslatef(0.6f, 0.35f, 0.6f);

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -1260,10 +1260,31 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.Radio")
         .withTextureName("textures/models/radio.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0.09, 0, 0.09, 0.77, 0.33, 0.93);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0.22, 0, 0.05, 0.92, 0.33, 0.9);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0.05, 0, 0.1, 0.9, 0.33, 0.77);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0.1, 0, 0.23, 0.95, 0.33, 0.92);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )    
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.7f, 0.7f, 0.7f);
             GL11.glTranslatef(0.65f, 0.58f, 0.6f);
-//            GL11.glRotatef(-45F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -252,7 +252,6 @@ public class TileEntities {
         .withName("locker")
         .withModelClassName("com.paneedah.mwc.models.Locker")
         .withTextureName("textures/models/locker.png")
-//        .withEquipementDispenseSound(sound)
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.5f, 0.5f, 0.5f);
@@ -826,7 +825,6 @@ public class TileEntities {
         .withName("vent")
         .withModelClassName("com.paneedah.mwc.models.Vent")
         .withTextureName("textures/models/vent.png")
-//        .withEquipementDispenseSound(sound)
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
             GL11.glScalef(1f, 1f, 1f);

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -15,7 +15,26 @@ public class TileEntities {
 
     public static void init(CommonProxy commonProxy) {
     	new TurretBaseFactory().createTileEntity(MWC.modContext);
-    	
+
+//        Example LootBox
+//        new LootBoxConfiguration()
+//        .withMaterial(Material.WOOD)
+//        .withName("blank")
+//        .withModelClassName("com.paneedah.mwc.models.Black")
+//        .withTextureName("textures/models/bodybag.png")
+////        .withEquipementDispenseSound(sound)
+//        .withCreativeTab(MWC.PropsTab)
+//        .withPositioning(tileEntity -> {
+//            GL11.glScalef(0.9f, 0.9f, 0.9f);
+//            GL11.glTranslatef(0.5f, -0.9f, 0.55f);
+//            GL11.glRotatef(-90F, 0f, 1f, 0f);
+//        })
+////        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
+////        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
+////        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
+//        .withEquipmentDispenseTimeout(10)
+//        .build(MWC.MOD_CONTEXT);
+
         new LootBoxConfiguration()
         .withMaterial(Material.ROCK)
         .withName("weapons_case")
@@ -48,9 +67,6 @@ public class TileEntities {
             GL11.glScalef(0.6f, 0.6f, 0.6f);
             GL11.glTranslatef(0.7f, 1.1f, 0.5f);
         })
-//        .withEquipmentOption(Guns.M4A1, EnumDifficulty.EASY, 1f)
-//        .withEquipmentOption(null, EnumDifficulty.EASY, 25f, 1)
-        .withEquipmentDispenseTimeout(10)
         .build(MWC.modContext);
         
         new LootBoxConfiguration()
@@ -58,7 +74,6 @@ public class TileEntities {
         .withName("weapons_case_small")
         .withModelClassName("com.paneedah.mwc.models.GunCaseSmall")
         .withTextureName("textures/models/gun_case_small.png")
-//        .withEquipementDispenseSound(sound)
         .withCreativeTab(MWC.PROPS_TAB)
         .withBoundingBox(
         		blockState -> {
@@ -217,10 +232,6 @@ public class TileEntities {
             GL11.glTranslatef(0.2f, 1.63f, 1.7f);
             GL11.glRotatef(90F, 0f, 1f, 0f);
         })
-        .withEquipmentOption(Guns.AK101, EnumDifficulty.EASY, 2f)
-        .withEquipmentOption(Guns.M38, EnumDifficulty.EASY, 2f)
-        .withEquipmentOption(Guns.APS, EnumDifficulty.EASY, 4f)
-        .withEquipmentDispenseTimeout(10)
         .build(MWC.modContext);
         
         new LootBoxConfiguration()
@@ -248,10 +259,6 @@ public class TileEntities {
             GL11.glTranslatef(0.7f, 1.85f, 1f);
 //            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
-//        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
-//        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
-//        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
-        .withEquipmentDispenseTimeout(10)
         .build(MWC.modContext);
         
         new LootBoxConfiguration()
@@ -259,17 +266,12 @@ public class TileEntities {
         .withName("scp_locker")
         .withModelClassName("com.paneedah.mwc.models.SCPLocker")
         .withTextureName("textures/models/scplocker.png")
-//        .withEquipementDispenseSound(sound)
         .withCreativeTab(MWC.PROPS_TAB)
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.8f, 0.8f, 0.8f);
             GL11.glTranslatef(0.5f, 0.45f, 0.6f);
             GL11.glRotatef(-90F, 0f, 1f, 0f);
         })
-//        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
-//        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
-//        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
-        .withEquipmentDispenseTimeout(10)
         .build(MWC.modContext);
         
         
@@ -688,24 +690,6 @@ public class TileEntities {
             GL11.glRotatef(-90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
-        
-//        new LootBoxConfiguration()
-//        .withMaterial(Material.WOOD)
-//        .withName("blank")
-//        .withModelClassName("com.paneedah.mwc.models.Black")
-//        .withTextureName("textures/models/bodybag.png")
-////        .withEquipementDispenseSound(sound)
-//        .withCreativeTab(MWC.PropsTab)
-//        .withPositioning(tileEntity -> {
-//            GL11.glScalef(0.9f, 0.9f, 0.9f);
-//            GL11.glTranslatef(0.5f, -0.9f, 0.55f);
-//            GL11.glRotatef(-90F, 0f, 1f, 0f);
-//        })
-////        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
-////        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
-////        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
-//        .withEquipmentDispenseTimeout(10)
-//        .build(MWC.MOD_CONTEXT);
         
         new LootBoxConfiguration()
         .withMaterial(Material.IRON)

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -190,6 +190,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.FridgeOpen")
         .withTextureName("textures/models/fridge.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glTranslatef(0.55f, 0f, 0.5f);
             GL11.glRotatef(-90F, 0f, 1f, 0f);
@@ -202,6 +224,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.FridgeClosed")
         .withTextureName("textures/models/fridge.png")
         .withCreativeTab(MWC.PROPS_TAB)
+                .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glTranslatef(0.55f, 0f, 0.5f);
             GL11.glRotatef(-90F, 0f, 1f, 0f);
@@ -252,6 +296,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.Locker")
         .withTextureName("textures/models/locker.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.5f, 0.5f, 0.5f);
             GL11.glTranslatef(0.7f, 1.85f, 1f);
@@ -264,6 +330,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.SCPLocker")
         .withTextureName("textures/models/scplocker.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 2, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.8f, 0.8f, 0.8f);
             GL11.glTranslatef(0.5f, 0.45f, 0.6f);
@@ -688,6 +776,29 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.Dumpster")
         .withTextureName("textures/models/dumpster.png")
         .withCreativeTab(MWC.PROPS_TAB)
+        .withCreativeTab(MWC.PROPS_TAB)
+        .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 2, 1, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 2, 1, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 2, 1, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 2, 1, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.9f, 0.9f, 0.9f);
             GL11.glTranslatef(0.6f, 0.2f, 0.5f);
@@ -1317,6 +1428,28 @@ public class TileEntities {
         .withModelClassName("com.paneedah.mwc.models.Sandbag")
         .withTextureName("textures/models/sandbag.png")
         .withCreativeTab(MWC.PROPS_TAB)
+                .withBoundingBox(
+        		blockState -> {
+        			AxisAlignedBB boundingBox = null;
+        			EnumFacing facing = blockState.getValue(CustomTileEntityBlock.FACING);
+        			switch(facing) {
+        			case WEST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 0.5, 1);
+        				break;
+        			case EAST:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 0.5, 1);
+        				break;
+        			case NORTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 0.5, 1);
+        				break;
+        			case SOUTH:
+        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 0.5, 1);
+        				break;
+        			default:
+        			}
+        			return boundingBox;
+        		}
+        )
         .withPositioning(tileEntity -> {
             GL11.glScalef(1f, 1f, 1f);
             GL11.glTranslatef(0.5f, 0f, 0.5f);

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -243,7 +243,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.6f, 0.6f, 0.6f);
             GL11.glTranslatef(0.7f, 1.13f, 0.5f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -256,7 +255,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.5f, 0.5f, 0.5f);
             GL11.glTranslatef(0.7f, 1.85f, 1f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -283,7 +281,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
         	GL11.glScalef(0.9f, 0.8f, 0.9f);
             GL11.glTranslatef(0.55f, 0.4f, 0.55f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -296,7 +293,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
         	GL11.glScalef(0.9f, 0.8f, 0.9f);
             GL11.glTranslatef(0.55f, 0.4f, 0.55f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -309,7 +305,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.9f, 0.9f, 0.9f);
             GL11.glTranslatef(0.7f, 0.25f, 0.6f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -322,7 +317,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.7f, 0.7f, 0.7f);
             GL11.glTranslatef(0.5f, 0.71f, 0.6f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -335,7 +329,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.9f, 0.9f, 0.9f);
             GL11.glTranslatef(0.7f, 0.25f, 0.6f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -634,7 +627,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(1.1f, 1.2f, 1f);
             GL11.glTranslatef(0.42f, -0.25f, 0.5f);
-//            GL11.glRotatef(-90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -1206,7 +1198,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.8f, 0.8f, 0.8f);
             GL11.glTranslatef(0.6f, 0.35f, 0.6f);
-//            GL11.glRotatef(-45F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -1219,7 +1210,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.9f, 0.9f, 0.9f);
             GL11.glTranslatef(0.6f, 0.175f, 0.6f);
-//            GL11.glRotatef(-45F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -1318,7 +1308,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(1f, 1f, 1f);
             GL11.glTranslatef(0.5f, 0f, 0.5f);
-//            GL11.glRotatef(90F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -1475,7 +1464,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(1.5f, 1.5f, 1.5f);
             GL11.glTranslatef(0.3f, -0.45f, -1f);
-//            GL11.glRotatef(-45F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         
@@ -1489,7 +1477,6 @@ public class TileEntities {
         .withPositioning(tileEntity -> {
             GL11.glScalef(0.5f, 0.5f, 0.5f);
             GL11.glTranslatef(1f, 1.5f, 1f);
-//            GL11.glRotatef(-45F, 0f, 1f, 0f);
         })
         .build(MWC.modContext);
         }

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -16,25 +16,6 @@ public class TileEntities {
     public static void init(CommonProxy commonProxy) {
     	new TurretBaseFactory().createTileEntity(MWC.modContext);
 
-//        Example LootBox
-//        new LootBoxConfiguration()
-//        .withMaterial(Material.WOOD)
-//        .withName("blank")
-//        .withModelClassName("com.paneedah.mwc.models.Black")
-//        .withTextureName("textures/models/bodybag.png")
-//        .withEquipementDispenseSound(sound)
-//        .withCreativeTab(MWC.PropsTab)
-//        .withPositioning(tileEntity -> {
-//            GL11.glScalef(0.9f, 0.9f, 0.9f);
-//            GL11.glTranslatef(0.5f, -0.9f, 0.55f);
-//            GL11.glRotatef(-90F, 0f, 1f, 0f);
-//        })
-//        .withEquipmentOption(Guns.M9A1, EnumDifficulty.EASY, 4f)
-//        .withEquipmentOption(Guns.M45A1, EnumDifficulty.EASY, 3f)
-//        .withEquipmentOption(Items.air, EnumDifficulty.EASY, 150f, 1)
-//        .withEquipmentDispenseTimeout(10)
-//        .build(MWC.MOD_CONTEXT);
-
         new LootBoxConfiguration()
         .withMaterial(Material.ROCK)
         .withName("weapons_case")


### PR DESCRIPTION
<!--
  🚀 For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  ⏱️ For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  📚 Before submitting a Pull Request, please ensure you've done the following:
  - 🛠️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [x] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [ ] 🌟 Quality Of Life
- [ ] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

Self-explanatory,   

## 🧐 The Rationale

I'm using the MWC props for deco in builds for a server I dev, and many props have the default hitbox which makes them hard to be used.

I know the props are gonna be changed and moved to another mod, but until then.

## 🎯 Key Objectives

- Remove old contagion code
- Give the radio a new hitbox (Uses the small weapons case's hitbox while I learn to use AxisAlignedBB)
- Give Locker and SCP Locker hitboxes

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

N/a

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed

