### PR TITLE
Added custom death messages (#143)

### DIFF
--- a/src/main/java/com/paneedah/weaponlib/CommonEventHandler.java
+++ b/src/main/java/com/paneedah/weaponlib/CommonEventHandler.java
@@ -29,6 +29,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;

--- a/src/main/java/com/paneedah/weaponlib/Weapon.java
+++ b/src/main/java/com/paneedah/weaponlib/Weapon.java
@@ -49,8 +49,7 @@ import java.util.stream.Collectors;
 import static com.paneedah.mwc.utils.ModReference.ID;
 import static com.paneedah.mwc.utils.ModReference.LOG;
 
-public class Weapon extends Item implements PlayerItemInstanceFactory<PlayerWeaponInstance, WeaponState>,
-AttachmentContainer, Reloadable, Inspectable, Modifiable, Updatable, IModernCrafting {
+public class Weapon extends Item implements PlayerItemInstanceFactory<PlayerWeaponInstance, WeaponState>, AttachmentContainer, Reloadable, Inspectable, Modifiable, Updatable, IModernCrafting {
 
     public enum ShellCasingEjectDirection { LEFT, RIGHT };
     

--- a/src/main/java/com/paneedah/weaponlib/WeaponSpawnEntity.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponSpawnEntity.java
@@ -7,6 +7,7 @@ import com.paneedah.weaponlib.network.packets.BloodPacketClient;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
@@ -14,6 +15,8 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.RayTraceResult.Type;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
@@ -81,10 +84,7 @@ public class WeaponSpawnEntity extends EntityProjectile {
             //PostProcessPipeline.createDistortionPoint((float) position.hitVec.x,(float)  position.hitVec.y, (float) position.hitVec.z, 2f, 3000);
             Explosion.createServerSideExplosion(weapon.getModContext(), world, this.getThrower(), this, position.hitVec.x, position.hitVec.y, position.hitVec.z, explosionRadius, false, true, isDestroyingBlocks, explosionParticleAgeCoefficient, smokeParticleAgeCoefficient, explosionParticleScaleCoefficient, smokeParticleScaleCoefficient, weapon.getModContext().getRegisteredTexture(explosionParticleTextureId), weapon.getModContext().getRegisteredTexture(smokeParticleTextureId), weapon.getModContext().getExplosionSound());
         } else if (position.entityHit != null) {
-            if (this.getThrower() != null)
-                position.entityHit.attackEntityFrom(DamageSource.causeThrownDamage(this, this.getThrower()), damage);
-            else
-                position.entityHit.attackEntityFrom(new DamageSource("thrown"), damage);
+            position.entityHit.attackEntityFrom(new ProjectileDamageSource("gun", weapon.getName(), this, this.getThrower()), damage);
 
             // Todo: Actually fix this, currently we are reproducing the effect of not apply knockback.
             //  If you are standing still it's not a big deal everything seems fine.
@@ -194,5 +194,34 @@ public class WeaponSpawnEntity extends EntityProjectile {
 
     public Weapon getWeapon() {
         return weapon;
+    }
+
+    public static class ProjectileDamageSource extends DamageSource {
+
+        private final String gunName;
+        private final Entity projectile;
+        private final Entity shooter;
+
+        public ProjectileDamageSource(String damageTypeIn, String gunName, Entity projectile, Entity shooter) {
+            super(damageTypeIn);
+            this.gunName = gunName;
+            this.projectile = projectile;
+            this.shooter = shooter;
+        }
+
+        @Override
+        public Entity getTrueSource() {
+            return this.projectile;
+        }
+
+        @Override
+        public Entity getImmediateSource() {
+            return this.shooter;
+        }
+
+        @Override
+        public ITextComponent getDeathMessage(EntityLivingBase entityLivingBaseIn) {
+            return new TextComponentTranslation("death.attack.gun", entityLivingBaseIn.getDisplayName(), this.shooter.getDisplayName(), this.gunName);
+        }
     }
 }

--- a/src/main/java/com/paneedah/weaponlib/WeaponSpawnEntity.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponSpawnEntity.java
@@ -221,6 +221,9 @@ public class WeaponSpawnEntity extends EntityProjectile {
 
         @Override
         public ITextComponent getDeathMessage(EntityLivingBase entityLivingBaseIn) {
+            if (this.shooter == null)
+                return new TextComponentTranslation("death.attack.gun.noshooter", entityLivingBaseIn.getDisplayName(), this.gunName);
+
             return new TextComponentTranslation("death.attack.gun", entityLivingBaseIn.getDisplayName(), this.shooter.getDisplayName(), this.gunName);
         }
     }

--- a/src/main/resources/assets/mwc/lang/en_US.lang
+++ b/src/main/resources/assets/mwc/lang/en_US.lang
@@ -1132,3 +1132,4 @@ config.rendering.enableFancyRainAndSnow.property.tooltip=Please keep this settin
 overlay.opendoor.name=Open Door
 
 death.attack.gun=%s was shot by %s using %s
+death.attack.gun.noshooter=%s was shot to death using %s

--- a/src/main/resources/assets/mwc/lang/en_US.lang
+++ b/src/main/resources/assets/mwc/lang/en_US.lang
@@ -1130,3 +1130,5 @@ config.rendering.enableFancyRainAndSnow.property.name=On-Screen Rain and Snow
 config.rendering.enableFancyRainAndSnow.property.tooltip=Please keep this setting DISABLED as it is currently broken.
 
 overlay.opendoor.name=Open Door
+
+death.attack.gun=%s was shot by %s using %s


### PR DESCRIPTION
## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [ ] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [ ] 🌟 Quality Of Life
- [x] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

Added custom death messages for when someone gets shot!
Current message: "{Player1} was by {Player2} using {WeaponName}"

## 🚦 Testing 

Tested this feature using LAN, since servers are still not working (@Desoroxxx we need that fixed).

![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/76911089/53d31c6f-fc63-43d6-adec-1a56168e5485)

## ⏮️ Backwards Compatibility 

Players who do not have the same version as server (or with a lang file that doesn't contain it) will just see `death.attack.gun`.
All languages (apart from `en_US`) will need to update.

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed
