### PR TITLE
Fix older versions of forge not working.

### DIFF
--- a/src/main/java/com/paneedah/mwc/proxies/ClientProxy.java
+++ b/src/main/java/com/paneedah/mwc/proxies/ClientProxy.java
@@ -112,9 +112,11 @@ public class ClientProxy extends CommonProxy {
         modelMesher.register(Armors.GasMaskM40, 0, new ModelResourceLocation(ID + ":m40gasmask_helmet", "inventory"));
 
         // Todo: Actually remove this once fixed.
-        
-        if (ForgeModContainer.allowEmissiveItems)
-            ForgeModContainer.allowEmissiveItems = false;
+
+        try {
+            if (ForgeModContainer.allowEmissiveItems)
+                ForgeModContainer.allowEmissiveItems = false;
+        } catch (NoSuchFieldError ignored) {}
 
         MC.getRenderManager().getSkinMap().forEach((model, playerRenderer) -> playerRenderer.addLayer(new EquipmentRenderer(playerRenderer)));
     }


### PR DESCRIPTION
Fix: older versions of 1.12.2 forge not starting cuz they don't have allowEmissiveItems as a setting.