### PR TITLE
Config the damage reduction of vests 

### DIFF
--- a/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
+++ b/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
@@ -17,8 +17,7 @@ import static com.paneedah.mwc.utils.ModReference.LOG;
 public class ModernConfigManager {
 	
 	private static final HashMap<Field, Property> elementMappings = new HashMap<>();
-	
-	//private static final List<Field> MODERN_CONFIG_FIELDS = new ArrayList<>();
+
 	
 	public static final String CATEGORY_RENDERING = "rendering";
 	public static final String CATEGORY_RENDERING_SCREENSHADERS = "rendering.screenshaders";
@@ -146,7 +145,22 @@ public class ModernConfigManager {
 
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "Where should the status bar be located?")
 	public static String statusBarPosition = "TOP_RIGHT";
+	
+	@RangeDouble(min=0.0, max=1.0)
+	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "M43A Chest Harness damage reduction")
+	public static String M43aChestHarnessReduction = "0.1";
 
+	@RangeDouble(min=0.0, max=1.0)
+	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "Molle Plate Carrier damage reduction")
+	public static String MollePlateCarrierReduction = "0.2";
+
+	@RangeDouble(min=0.0, max=1.0)
+	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "SWAT Vest damage reduction")
+	public static String SwatVestReduction = "0.3";
+
+	@RangeDouble(min=0.0, max=1.0)
+	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "USMC Vest damage reduction")
+	public static String UsmcVestReduction = "0.4";
 
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=5.0)

--- a/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
+++ b/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
@@ -145,20 +145,24 @@ public class ModernConfigManager {
 
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "Where should the status bar be located?")
 	public static String statusBarPosition = "TOP_RIGHT";
-	
-	@RangeDouble(min=0.0, max=1.0)
+
+	@RequiresMcRestart
+	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "M43A Chest Harness damage reduction")
 	public static String M43aChestHarnessReduction = "0.1";
 
-	@RangeDouble(min=0.0, max=1.0)
+	@RequiresMcRestart
+	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "Molle Plate Carrier damage reduction")
 	public static String MollePlateCarrierReduction = "0.2";
 
-	@RangeDouble(min=0.0, max=1.0)
+	@RequiresMcRestart
+	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "SWAT Vest damage reduction")
 	public static String SwatVestReduction = "0.3";
 
-	@RangeDouble(min=0.0, max=1.0)
+	@RequiresMcRestart
+	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "USMC Vest damage reduction")
 	public static String UsmcVestReduction = "0.4";
 

--- a/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
+++ b/src/main/java/com/paneedah/weaponlib/config/ModernConfigManager.java
@@ -149,22 +149,22 @@ public class ModernConfigManager {
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "M43A Chest Harness damage reduction")
-	public static String M43aChestHarnessReduction = "0.1";
+	public static double M43aChestHarnessReduction = "0.1";
 
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "Molle Plate Carrier damage reduction")
-	public static String MollePlateCarrierReduction = "0.2";
+	public static double MollePlateCarrierReduction = "0.2";
 
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "SWAT Vest damage reduction")
-	public static String SwatVestReduction = "0.3";
+	public static double SwatVestReduction = "0.3";
 
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=1.0)
 	@ConfigSync(category = CATEGORY_GAMEPLAY, comment = "USMC Vest damage reduction")
-	public static String UsmcVestReduction = "0.4";
+	public static double UsmcVestReduction = "0.4";
 
 	@RequiresMcRestart
 	@RangeDouble(min=0.1, max=5.0)


### PR DESCRIPTION
## 🤔 What type of PR is this? (check all applicable)

- [x] 🍕 Addition
- [ ] ⌨️ Productivity
- [ ] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [x] ⚙️ Configuration
- [x] 🌟 Quality Of Life
- [x] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

Adds configs for the damage  

## 🧐 The Rationale

Vests are still in a semi-broken state, this would allow pack makers to balance for themselves  

## 🎯 Key Objectives

Add config for all vests. Vests that are different colors will share the same reduction (Molle Green = 0.3, Molle Urban = 0.3)

## 🚦 Testing 

Working on it, not done yet

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

<!-- Visual changes require screenshots -->

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed
