### PR TITLE
Fix Dumpster when facing East

### DIFF
--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -987,7 +987,7 @@ public class TileEntities {
         				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 1, 2);
         				break;
         			case EAST:
-        				boundingBox = new AxisAlignedBB(0, 0, -1, 1, 1, 1)
+        				boundingBox = new AxisAlignedBB(0, 0, -1, 1, 1, 1);
         				break;
         			case NORTH:
         				boundingBox = new AxisAlignedBB(-1, 0, 0, 1, 1, 1);

--- a/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
+++ b/src/main/java/com/paneedah/mwc/tileentities/TileEntities.java
@@ -987,7 +987,7 @@ public class TileEntities {
         				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 1, 2);
         				break;
         			case EAST:
-        				boundingBox = new AxisAlignedBB(0, 0, 0, 1, 1, 2);
+        				boundingBox = new AxisAlignedBB(0, 0, -1, 1, 1, 1)
         				break;
         			case NORTH:
         				boundingBox = new AxisAlignedBB(-1, 0, 0, 1, 1, 1);


### PR DESCRIPTION
## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [x] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [ ] 🌟 Quality Of Life
- [ ] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

The dumpster's hitbox was offset by one when facing east

## 🧐 The Rationale

Broken hitbox

## 🎯 Key Objectives

Fix the hitbox

## 🚦 Testing 

![Capture](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/113206902/7dca2608-415b-4836-8377-ba52e5160bb3)

Fixed hitbox

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

#229 

## 🖼️ Screenshots/Recordings

See "Testing"

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed
