### PR TITLE
fix night vision goggles not working with hardcore darkness mod

### DIFF
--- a/src/main/java/com/paneedah/mwc/handlers/CommonEventHandler.java
+++ b/src/main/java/com/paneedah/mwc/handlers/CommonEventHandler.java
@@ -1,8 +1,17 @@
 package com.paneedah.mwc.handlers;
 
+import com.paneedah.mwc.network.handlers.NightVisionToggleMessageHandler;
+import com.paneedah.weaponlib.CustomArmor;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.GameRules;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
 
 public class CommonEventHandler {
 
@@ -11,5 +20,24 @@ public class CommonEventHandler {
         worldLoadEvent.getWorld().getGameRules().addGameRule("reconcileAmmunition", "true", GameRules.ValueType.BOOLEAN_VALUE);
         // This is off by default since it seems to rollback attachments maybe something is not getting updated
         worldLoadEvent.getWorld().getGameRules().addGameRule("reconcileAttachments", "false", GameRules.ValueType.BOOLEAN_VALUE);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTickEvent(PlayerTickEvent playerTickEvent) {
+        EntityPlayer player = playerTickEvent.player;
+        ItemStack helmetStack = player.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
+        if (helmetStack.getItem() instanceof CustomArmor
+            && ((CustomArmor) helmetStack.getItem()).hasNightVision()) {
+            NBTTagCompound tagCompound = helmetStack.getTagCompound();
+            boolean nightVisionOn = tagCompound != null && tagCompound.getBoolean(
+                NightVisionToggleMessageHandler.TAG_NIGHT_VISION_STATE);
+            if (nightVisionOn) {
+                player.addPotionEffect(
+                    new PotionEffect(MobEffects.NIGHT_VISION, 210, 0, true, false));
+            } else {
+                player.removePotionEffect(MobEffects.NIGHT_VISION);
+            }
+            ;
+        }
     }
 }


### PR DESCRIPTION
<!--
  🚀 For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  ⏱️ For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  📚 Before submitting a Pull Request, please ensure you've done the following:
  - 🛠️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📖 Update any related documentation and include any relevant screenshots.
-->

## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [X] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [ ] 🌟 Quality Of Life
- [ ] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

Fixes compatibility issue with [hardcore darkness](https://www.curseforge.com/minecraft/mc-mods/hardcore-darkness) and night vision goggles

## 🧐 The Rationale

When using the mod with MWC night vision goggles, it would be pitch black even if night vision was on.

## 🎯 Key Objectives

Have night vision work with hardcore darkness

## 🚦 Testing 

I tested with/without hardcore darkness mod

## 🖼️ Screenshots/Recordings
Before:
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/60529713/d335227f-9f6c-4ffd-9afb-9afc8ad802f9)
After:
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/60529713/471d3880-7477-435b-b21b-f05249da44cc)

<!-- Visual changes require screenshots -->

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [X] 🙅 no documentation needed

<!-- note: PRs with deleted sections will be marked invalid -->
