### PR TITLE
Even more Lang changes

### DIFF
--- a/src/main/resources/assets/mwc/lang/en_US.lang
+++ b/src/main/resources/assets/mwc/lang/en_US.lang
@@ -436,7 +436,6 @@ item.baseball_bat.name=Baseball Bat
 item.baseball_bat_nails.name=Baseball Bat w/ Nails
 item.night_stick.name=Night Stick
 
-item.gas_can.name=Gas Can (PROP)
 item.mwc_wcam.name=Camera
 item.mwc_tablet.name=Tablet
 
@@ -954,9 +953,9 @@ tile.mwc_desk_middle_alt1.name=Desk Middle (ALT1)
 tile.mwc_desk_right.name=Desk Right
 tile.mwc_desk_right_alt1.name=Desk Right (ALT1)
 tile.mwc_desk_shelf.name=Desk Shelf
-tile.mwc_desk_shelf_alt1.name=Desk Shelf (A1)
-tile.mwc_desk_shelf_alt2.name=Desk Shelf (A2)
-tile.mwc_desk_shelf_alt3.name=Desk Shelf (A3)
+tile.mwc_desk_shelf_alt1.name=Desk Shelf (ALT1)
+tile.mwc_desk_shelf_alt2.name=Desk Shelf (ALT2)
+tile.mwc_desk_shelf_alt3.name=Desk Shelf (ALT3)
 tile.mwc_barrier.name=Barrier
 tile.mwc_barrier_rotated.name=Barrier (Rotated)
 tile.mwc_body_bag.name=Body Bag


### PR DESCRIPTION
## 🤔 What type of PR is this? (check all applicable)

- [ ] 🍕 Addition
- [ ] ⌨️ Productivity
- [ ] 🐛 Bug Fix
- [ ] 🔥 Optimization
- [ ] ⚙️ Configuration
- [x] 🌟 Quality Of Life
- [ ] ✨ Enhancement
- [ ] 📝 Documentation

## 📝 Description

Removes Lang info for the (now-removed) gas can and renames Desk Shelf (A1) to Desk Shelf (ALT1)

## 🧐 The Rationale

The gas can doesn't exist anymore, and naming constancy between items

## 🎯 Key Objectives

Not break anything 

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 no documentation needed
