### PR TITLE
Workbench item consume

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -126,7 +126,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed ammunition press animating even when it wasn't actively crafting
 - Fixed ammunition press setting the ammunition of the magazines after they where crafted when this isn't necessary anymore
 - Fixed tooltip formatting in the ammunition press
-- Fixed the workbench not consuming items within different stacks when crafting
+- Fixed workbench and ammunition press handling their inventory stack by stack instead of all at once
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -126,6 +126,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed ammunition press animating even when it wasn't actively crafting
 - Fixed ammunition press setting the ammunition of the magazines after they where crafted when this isn't necessary anymore
 - Fixed tooltip formatting in the ammunition press
+- Fixed the workbench not consuming items within different stacks when crafting
 
 ### Removed
 

--- a/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
+++ b/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
@@ -185,12 +185,21 @@ public class StationPacket implements IMessage {
 
 		            		// Verify
 		            		for(CraftingEntry stack : modernRecipe) {
+								int count = stack.getCount();
 		            			if(!stack.isOreDictionary()) {
 		            				// Does it even have that item? / Does it have enough of that item?
-			            			if(!itemList.containsKey(stack.getItem()) || stack.getCount() > itemList.get(stack.getItem()).getCount())
-			            				return;
+									for (int i = 23; i < station.mainInventory.getSlots(); ++i) {
+										final ItemStack iS = station.mainInventory.getStackInSlot(i);
+										if (iS.getItem() == stack.getItem()) {
+											if(count != 0) {
+												count -= iS.getCount();
+												iS.shrink(stack.getCount());
 
-			            			toConsume.add(new Pair<Item, Integer>(stack.getItem(), stack.getCount()));
+												if (count == 0)
+													break;
+											}
+										}
+									}
 		            			} else {
 		            				// Stack is an OreDictionary term
 		            				boolean hasAny = false;


### PR DESCRIPTION
## 📝 Description

Allows for the custom workbench to utilize its inventory more effectively by consuming items even if they're in different slots.

## ❌ Non Goals

Adding full support for OreDict items.

## 🚦 Testing 

Tested locally.

## ⏮️ Backwards Compatibility 

Will work fine.

## 📚 Related Issues & Documents

Issue #35 

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where items in different stacks were not being consumed correctly during crafting in the workbench.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->