### PR TITLE
Crafting stations hotfixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -127,6 +127,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed ammunition press setting the ammunition of the magazines after they where crafted when this isn't necessary anymore
 - Fixed tooltip formatting in the ammunition press
 - Fixed workbench and ammunition press handling their inventory stack by stack instead of all at once
+- Fixed crafting stations GUI not updating after clicking craft showing outdated information
 - Fixed crafting stations buttons playing sounds even when disabled
 - Fixed crafting stations craft button being enabled even when no crafting recipe was selected
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -128,6 +128,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed tooltip formatting in the ammunition press
 - Fixed workbench and ammunition press handling their inventory stack by stack instead of all at once
 - Fixed crafting stations buttons playing sounds even when disabled
+- Fixed crafting stations craft button being enabled even when no crafting recipe was selected
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -127,6 +127,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed ammunition press setting the ammunition of the magazines after they where crafted when this isn't necessary anymore
 - Fixed tooltip formatting in the ammunition press
 - Fixed workbench and ammunition press handling their inventory stack by stack instead of all at once
+- Fixed crafting stations buttons playing sounds even when disabled
 
 ### Removed
 

--- a/src/main/java/com/paneedah/weaponlib/crafting/ammopress/GUIContainerAmmoPress.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/ammopress/GUIContainerAmmoPress.java
@@ -113,7 +113,7 @@ public class GUIContainerAmmoPress extends GUIContainerStation<TileEntityAmmoPre
 		super.updateScreen();
 		if(this.tileEntity.getCraftingQueue().size() > 4) {
 			craftButton.setErrored(true);
-		} else {
+		} else if (hasSelectedCraftingPiece()) {
 			craftButton.setErrored(false);
 		}
 	}

--- a/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
@@ -233,11 +233,14 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 						foundSomething = true;
 						hasAvailiableMaterials.put(is.getItem(), true);
 						break;
+					} else {
+						hasRequiredItems = false;
 					}
 				}
 				
 				if(!foundSomething) {
 					hasRequiredItems = false;
+					hasAvailiableMaterials.put(is.getItem(), false);
 				}
 			}
  			

--- a/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
@@ -136,6 +136,9 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 				"DISMANTLE").withStandardState(GRAY, 0, 283).withHoveredState(GOLD, 0, 300)
 						.withErroredState(RED, 0, 317).withPageRestriction(1);
 		
+
+		craftButton.setErrored(true);
+
 		addButton(craftButton);
 		addButton(leftArrow);
 		addButton(rightArrow);
@@ -183,6 +186,7 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 	}
 	
 	public void setCraftingMode(int mode) {
+		craftButton.setErrored(true);
 		this.craftingMode = mode;
 	}
 	
@@ -247,6 +251,7 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 		}
 
 		if(requiresMaterialsToSubmitCraftRequest()) this.craftButton.setErrored(!hasRequiredItems);
+		else this.craftButton.setErrored(false);
 
 	}
 	

--- a/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
@@ -238,7 +238,7 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 					}
 				}
 				
-				if(!foundSomething) {
+				if(!foundSomething || is.getCount() > counter.get(is.getItem())) {
 					hasRequiredItems = false;
 					hasAvailiableMaterials.put(is.getItem(), false);
 				}

--- a/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/base/GUIContainerStation.java
@@ -233,14 +233,11 @@ public abstract class GUIContainerStation<T extends TileEntityStation> extends G
 						foundSomething = true;
 						hasAvailiableMaterials.put(is.getItem(), true);
 						break;
-					} else {
-						hasRequiredItems = false;
 					}
 				}
 				
-				if(!foundSomething || is.getCount() > counter.get(is.getItem())) {
+				if(!foundSomething) {
 					hasRequiredItems = false;
-					hasAvailiableMaterials.put(is.getItem(), false);
 				}
 			}
  			

--- a/src/main/java/com/paneedah/weaponlib/crafting/workbench/GUIButtonCustom.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/workbench/GUIButtonCustom.java
@@ -2,8 +2,11 @@ package com.paneedah.weaponlib.crafting.workbench;
 
 import com.paneedah.weaponlib.render.gui.GUIRenderHelper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.function.Supplier;
@@ -289,4 +292,11 @@ public class GUIButtonCustom extends GuiButton {
 		
 	}
 
+	@Override
+	public void playPressSound(SoundHandler soundHandlerIn) {
+		if ((disabledCheck != null && disabledCheck.get()) || isErrored)
+			return;
+
+		soundHandlerIn.playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+	}
 }

--- a/src/main/java/com/paneedah/weaponlib/crafting/workbench/GUIContainerWorkbench.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/workbench/GUIContainerWorkbench.java
@@ -139,6 +139,7 @@ public class GUIContainerWorkbench extends GUIContainerStation<TileEntityWorkben
 			assaultSelector.toggleOff();
 			gearSelector.toggleOff();
 			setCraftingMode(3);
+			setSelectedCraftingPiece(null);
 			fillFilteredList();
 		} else if(button == gearSelector) {
 			((GUIButtonCustom) button).toggleOn();
@@ -147,6 +148,7 @@ public class GUIContainerWorkbench extends GUIContainerStation<TileEntityWorkben
 			modSelector.toggleOff();
 			
 			setCraftingMode(CraftingGroup.GEAR.getID());
+			setSelectedCraftingPiece(null);
 			fillFilteredList();
 			
 			

--- a/src/main/java/com/paneedah/weaponlib/network/packets/StationClientPacket.java
+++ b/src/main/java/com/paneedah/weaponlib/network/packets/StationClientPacket.java
@@ -65,8 +65,10 @@ public class StationClientPacket implements IMessage {
 		public IMessage onMessage(StationClientPacket message, MessageContext messageContext) {
 			mc.addScheduledTask(() -> {
 				TileEntity tileEntity = mc.world.getTileEntity(message.pos);
-				if(tileEntity != null && tileEntity instanceof TileEntityStation)
+				if(tileEntity != null && tileEntity instanceof TileEntityStation) {
 					((TileEntityStation) tileEntity).readBytesFromClientSync(message.copiedBuf);
+					((TileEntityStation) tileEntity).pushInventoryRefresh = true;
+				}
 			});
 
 			return null;

--- a/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
+++ b/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
@@ -25,6 +25,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.OreDictionary;
+import org.lwjgl.Sys;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -171,70 +172,53 @@ public class StationPacket implements IMessage {
 
 		            			modContext.getChannel().sendToAllAround(new StationClientPacket(station.getWorld(), message.teLocation), new TargetPoint(0, message.teLocation.getX(), message.teLocation.getY(), message.teLocation.getZ(), 20));
 
-		            			return;
+								return;
 	            			}
+
 	            			CraftingEntry[] modernRecipe = CraftingRegistry.getModernCrafting(message.craftingGroup, message.craftingName).getModernRecipe();
-		            		if(modernRecipe == null)
+		            		if (modernRecipe == null)
 								return;
 
-		            		// Add all items to an item list to verify that they exist.
-		            		HashMap<Item, ItemStack> itemList = new HashMap<>(27, 0.7f);
-		            		for(int i = 23; i < station.mainInventory.getSlots(); ++i)
-		            			itemList.put(station.mainInventory.getStackInSlot(i).getItem(), station.mainInventory.getStackInSlot(i));
+							final HashMap<Item, HashMap<ItemStack, Integer>> itemRemovalList = new HashMap<>();
 
-		            		ArrayList<Pair<Item, Integer>> toConsume = new ArrayList<>();
+							// Calculate the itemstacks to remove
+							for (CraftingEntry stack : modernRecipe) {
+								itemRemovalList.computeIfAbsent(stack.getItem(), k -> new HashMap<>());
+								final Item stackItem = stack.getItem();
+								final int requiredCount = stack.getCount();
 
-		            		// Verify
-		            		for(CraftingEntry stack : modernRecipe) {
-								int count = stack.getCount();
-		            			if(!stack.isOreDictionary()) {
-		            				// Does it even have that item? / Does it have enough of that item?
-									for (int i = 23; i < station.mainInventory.getSlots(); ++i) {
-										final ItemStack iS = station.mainInventory.getStackInSlot(i);
-										if (iS.getItem() == stack.getItem()) {
-											if(count != 0) {
-												count -= iS.getCount();
-												iS.shrink(stack.getCount());
+								for (int i = 23; i < station.mainInventory.getSlots(); ++i) {
+									final ItemStack iS = station.mainInventory.getStackInSlot(i);
+									if (iS.getItem() != stackItem)
+										continue;
 
-												if (count == 0)
-													break;
-											}
-										}
+									final int existingCount = itemRemovalList.get(stackItem).values().stream().mapToInt(Integer::intValue).sum();
+									if (existingCount >= requiredCount)
+										break;
+
+									final int iSCount = iS.getCount();
+									if (existingCount + iSCount >= requiredCount) {
+										itemRemovalList.get(stackItem).put(iS, requiredCount - existingCount);
+										break;
 									}
-		            			} else {
-		            				// Stack is an OreDictionary term
-		            				boolean hasAny = false;
-		            				NonNullList<ItemStack> list = OreDictionary.getOres(stack.getOreDictionaryEntry());
-		            				for(ItemStack toTest : list) {
-		            					if(itemList.containsKey(toTest.getItem()) && stack.getCount() <= itemList.get(toTest.getItem()).getCount()) {
-		            						hasAny = true;
-		            						toConsume.add(new Pair<Item, Integer>(toTest.getItem(), stack.getCount()));
-		            						break;
-		            					}
-		            				}
 
-		            				if(!hasAny) return;
-		            			}
-		            		}
+									itemRemovalList.get(stackItem).put(iS, iSCount);
+								}
+							}
 
-		            		/*
-		            		// Consume materials
-		            		for(CraftingEntry stack : modernRecipe) {
-		            			if(!stack.isOreDictionary()) {
-		            				itemList.get(stack.getItem()).shrink(stack.getCount());
-		            			} else {
+							// Verify
+							for (CraftingEntry stack : modernRecipe) {
+								if (!stack.isOreDictionary()) {
+									final Item stackItem = stack.getItem();
+									if (!itemRemovalList.containsKey(stackItem) || itemRemovalList.get(stackItem).values().stream().mapToInt(Integer::intValue).sum() < stack.getCount())
+										return;
+								}
+							}
 
-		            				List<ItemStack> list = OreDictionary.getOres(stack.getOreDictionaryEntry());
-		            				for(ItemStack test : list) {
-
-		            				}
-		            				itemList.get(stack.getItem()).shrink(stack.getCount());
-		            			}
-
-		            		}*/
-
-		            		for(Pair<Item, Integer> i : toConsume)
-		            			itemList.get(i.first()).shrink(i.second());
+							// Remove the items
+							for (Item i : itemRemovalList.keySet())
+								for (ItemStack iS : itemRemovalList.get(i).keySet())
+									iS.shrink(itemRemovalList.get(i).get(iS));
 
 		            		if(station instanceof TileEntityWorkbench) {
 		            			TileEntityWorkbench workbench = (TileEntityWorkbench) station;

--- a/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
+++ b/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
@@ -25,7 +25,6 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.OreDictionary;
-import org.lwjgl.Sys;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
+++ b/src/main/java/com/paneedah/weaponlib/network/packets/StationPacket.java
@@ -11,7 +11,6 @@ import com.paneedah.weaponlib.crafting.base.TileEntityStation;
 import com.paneedah.weaponlib.crafting.workbench.TileEntityWorkbench;
 import io.netty.buffer.ByteBuf;
 import io.redstudioragnarok.redcore.utils.MathUtil;
-import io.redstudioragnarok.redcore.utils.ModReference;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -192,19 +191,14 @@ public class StationPacket implements IMessage {
 		            				// Does it even have that item? / Does it have enough of that item?
 									for (int i = 23; i < station.mainInventory.getSlots(); ++i) {
 										final ItemStack iS = station.mainInventory.getStackInSlot(i);
-										if (itemList.containsKey(iS.getItem()) && stack.getCount() <= iS.getCount()) {
-											if (iS.getItem() == stack.getItem()) {
-												if (count != 0) {
-													count -= iS.getCount();
-													iS.shrink(stack.getCount());
+										if (iS.getItem() == stack.getItem()) {
+											if(count != 0) {
+												count -= iS.getCount();
+												iS.shrink(stack.getCount());
 
-													if (count == 0)
-														break;
-												}
+												if (count == 0)
+													break;
 											}
-										} else {
-											ModReference.LOG.error("You have encountered a bug please report this to the Developers");
-											return;
 										}
 									}
 		            			} else {


### PR DESCRIPTION
## 📝 Description

This PR brings a couple of hotfixes to the crafting stations.

## 🎯 Goals

- Fix an issue introduced in Dev 16 where the crafting stations would eat but not craft items
- Fix other issues found along the way related to crafting stations

## ❌ Non Goals

- It is not a goal to touch the craft mapping system
- It is not a goal to enhance or add features to the crafting stations

## 🚦 Testing 

Testing for both of the crafting stations involving different combinations of inventory and crafts by both me and @Paneedah.

## ⏮️ Backwards Compatibility 

This is fully backward compatible with Dev 16 and previous.

## 📚 Related Issues & Documents

Fixes #331
Fixes #35

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Crafting stations GUI now updates correctly after crafting.
	- Disabled buttons no longer emit sound effects.
	- Craft button is disabled when no recipe is selected to prevent unintended behavior.

- **Refactor**
	- Improved internal logic for crafting workflow and GUI interactions.

- **Style**
	- Adjusted GUI elements for better user experience.

- **Chores**
	- Updated network packet handling for more responsive inventory refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->