### PR TITLE
Drop items instead of destroying them

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 - Fixed fog obscuring vision too much in optical scopes
 - Fixed weapons destroying magazine when unloading with a full inventory
 - Fixed magazines destroying bullets when unloading with a full inventory
+- Fixed attachments destroying themselves when removing them with a full inventory
 
 ## Modern Warfare Cubed Version 0.1.3 Changelog - 2024-03-15
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,15 @@ and this project follows to [Ragnarök Versioning Convention](https://gist.githu
 
 **BEFORE UPDATING TO MWC 0.1 MAKE SURE TO BACKUP YOUR WORLDS, THINGS WILL DISAPPEAR**
 
+### Changed
+
+- Weapons will not prevent you from unloading with a full inventory anymore, instead they will drop their magazines on the ground
+
 ### Fixed
 
 - Fixed fog obscuring vision too much in optical scopes
+- Fixed weapons destroying magazine when unloading with a full inventory
+- Fixed magazines destroying bullets when unloading with a full inventory
 
 ## Modern Warfare Cubed Version 0.1.3 Changelog - 2024-03-15
 

--- a/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
@@ -142,12 +142,10 @@ public class MagazineReloadAspect implements Aspect<MagazineState, PlayerMagazin
 
     
     private void evaluateUnload(UnloadPermit p, PlayerMagazineInstance magazineInstance) {
-
-    	
-    	
         if(!(magazineInstance.getPlayer() instanceof EntityPlayer)) {
             return;
         }
+
         ItemStack magazineStack = magazineInstance.getItemStack();
 
         Status status = Status.DENIED;
@@ -175,7 +173,9 @@ public class MagazineReloadAspect implements Aspect<MagazineState, PlayerMagazin
             
             ItemStack stack = new ItemStack(compatibleBullets.get(0));
             stack.setCount(currentAmmo);
-            player.addItemStackToInventory(stack);
+
+            if (!player.addItemStackToInventory(stack))
+                player.dropItem(stack, false);
             
             if(originalFlag) {
             	 Tags.setAmmo(magazineStack, 0);

--- a/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
@@ -225,6 +225,7 @@ public class MagazineReloadAspect implements Aspect<MagazineState, PlayerMagazin
         if(!(magazineInstance.getPlayer() instanceof EntityPlayer)) {
             return;
         }
+
         ItemStack magazineStack = magazineInstance.getItemStack();
 
         Status status = Status.DENIED;

--- a/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/MagazineReloadAspect.java
@@ -225,7 +225,6 @@ public class MagazineReloadAspect implements Aspect<MagazineState, PlayerMagazin
         if(!(magazineInstance.getPlayer() instanceof EntityPlayer)) {
             return;
         }
-
         ItemStack magazineStack = magazineInstance.getItemStack();
 
         Status status = Status.DENIED;

--- a/src/main/java/com/paneedah/weaponlib/WeaponAttachmentAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponAttachmentAspect.java
@@ -467,7 +467,8 @@ public final class WeaponAttachmentAspect implements Aspect<WeaponState, PlayerW
 			// Item must be added to the same spot the next attachment comes from or to any
 			// spot if there is no next attachment
 			if (lookupResult.index == -1) {
-				player.inventory.addItemStackToInventory(new ItemStack(currentAttachment));
+				if (!player.inventory.addItemStackToInventory(new ItemStack(currentAttachment)))
+					player.dropItem(new ItemStack(currentAttachment), false);
 			} else if (player.inventory.mainInventory.get(lookupResult.index) == null || player.inventory.mainInventory.get(lookupResult.index).getItem() == Items.AIR) {
 				player.inventory.mainInventory.set(lookupResult.index, new ItemStack(currentAttachment));
 			}
@@ -699,8 +700,7 @@ public final class WeaponAttachmentAspect implements Aspect<WeaponState, PlayerW
 	 * @param player
 	 * @return
 	 */
-	ItemAttachment<Weapon> removeAttachment(AttachmentCategory attachmentCategory,
-			PlayerWeaponInstance weaponInstance) {
+	ItemAttachment<Weapon> removeAttachment(AttachmentCategory attachmentCategory, PlayerWeaponInstance weaponInstance) {
 
 		int[] activeAttachmentIds = weaponInstance.getActiveAttachmentIds();
 		int activeAttachmentIdForThisCategory = activeAttachmentIds[attachmentCategory.ordinal()];
@@ -714,8 +714,7 @@ public final class WeaponAttachmentAspect implements Aspect<WeaponState, PlayerW
 		}
 
 		if (currentAttachment != null && currentAttachment.getRemove() != null) {
-			currentAttachment.getRemove().apply(currentAttachment, weaponInstance.getWeapon(),
-					weaponInstance.getPlayer());
+			currentAttachment.getRemove().apply(currentAttachment, weaponInstance.getWeapon(), weaponInstance.getPlayer());
 		}
 
 		if (currentAttachment != null) {

--- a/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
@@ -140,9 +140,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
         }
     };
 
-
-    private Predicate<PlayerWeaponInstance> inventoryHasFreeSlots = weaponInstance -> weaponInstance.getPlayer() instanceof EntityPlayer && !(((EntityPlayer) weaponInstance.getPlayer()).inventory.getFirstEmptyStack() == -1);
-
     private static Predicate<PlayerWeaponInstance> alertTimeoutExpired = instance -> System.currentTimeMillis() >= ALERT_TIMEOUT + instance.getStateUpdateTimestamp();
 
     private static Predicate<PlayerWeaponInstance> inspectTimeoutExpired = instance -> System.currentTimeMillis() >= INSPECT_TIMEOUT + instance.getStateUpdateTimestamp();

--- a/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
@@ -11,11 +11,9 @@ import com.paneedah.weaponlib.state.Aspect;
 import com.paneedah.weaponlib.state.Permit;
 import com.paneedah.weaponlib.state.Permit.Status;
 import com.paneedah.weaponlib.state.StateManager;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.text.TextComponentString;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -318,7 +316,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
                 .in(this)
                 .prepare((c, f, t) -> { prepareUnload(c); }, unloadAnimationCompleted)
                 .change(WeaponState.READY).to(WeaponState.UNLOAD)
-                .when(magazineAttached.and(inventoryHasFreeSlots))
+                .when(magazineAttached)
                 .withPermit((s, c) -> new UnloadPermit(s), modContext.getPlayerItemInstanceRegistry()::update, permitManager)
                 .withAction((c, f, t, p) -> completeClientUnload(c, (UnloadPermit) p))
                 .manual()
@@ -327,12 +325,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
                 .change(WeaponState.UNLOAD).to(WeaponState.READY)
                 .when(loadAfterUnloadEnabled.negate().or(unloadTimeoutExpired))
                 .automatic()
-
-                .in(this)
-                .change(WeaponState.READY).to(WeaponState.ALERT)
-                .when(inventoryHasFreeSlots.negate())
-                .withAction(this::inventoryFullAlert)
-                .manual()
 
                 .in(this).change(WeaponState.ALERT).to(WeaponState.READY)
                 .when(alertTimeoutExpired)
@@ -778,11 +770,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             stateManager.changeState(this, weaponInstance, WeaponState.LOAD, WeaponState.ALERT);
             weaponInstance.setLoadAfterUnloadEnabled(false);
         }
-    }
-
-    public void inventoryFullAlert(PlayerWeaponInstance weaponInstance) {
-        if (weaponInstance.getPlayer() instanceof EntityPlayer)
-            ((EntityPlayer) weaponInstance.getPlayer()).sendStatusMessage(new TextComponentString(I18n.format("gui.inventoryFull")), true);
     }
 
     public void inspect(PlayerWeaponInstance weaponInstance) {

--- a/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
@@ -627,7 +627,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
         else if (attachment instanceof ItemMagazine && !player.isCreative()) {
             ItemStack attachmentItemStack = ((ItemMagazine) attachment).create(originalAmmo);
             if (!player.inventory.addItemStackToInventory(attachmentItemStack))
-                LOG.error("Cannot add attachment " + attachment + " for " + instance + "back to the inventory");
+                player.dropItem(attachmentItemStack, false);
             p.setStatus(Status.GRANTED);
         }
     }
@@ -739,7 +739,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
                 previousMagazine = attachment;
                 ItemStack attachmentItemStack = ((ItemMagazine) attachment).create(Tags.getAmmo(weaponItemStack));
                 if (!player.inventory.addItemStackToInventory(attachmentItemStack))
-                    LOG.error("Cannot add attachment " + attachment + " for " + weaponInstance + "back to the inventory");
+                    player.dropItem(attachmentItemStack, false);
             }
 
             Tags.setAmmo(weaponItemStack, 0);

--- a/src/main/resources/assets/mwc/lang/en_US.lang
+++ b/src/main/resources/assets/mwc/lang/en_US.lang
@@ -1068,7 +1068,6 @@ gui.firearmMode=Firearm mode: %s
 gui.firearmMode.semi=Semi
 gui.firearmMode.auto=Auto
 gui.firearmMode.burst=Burst
-gui.inventoryFull=Inventory full
 gui.currentZoom=Zoom: %s%%
 gui.grenadeExplodes=Explodes in %s sec
 gui.coolingDown=Cooling down...

--- a/src/main/resources/assets/mwc/lang/es_ES.lang
+++ b/src/main/resources/assets/mwc/lang/es_ES.lang
@@ -1055,7 +1055,6 @@ gui.firearmMode=Modo de fuego: %s
 gui.firearmMode.semi=Semi
 gui.firearmMode.auto=Auto
 gui.firearmMode.burst=Rafaga
-gui.inventoryFull=Inventory full
 gui.currentZoom=Zoom: %s%%
 gui.grenadeExplodes=Explota en %s seg
 gui.coolingDown=Cooling down...

--- a/src/main/resources/assets/mwc/lang/pt_BR.lang
+++ b/src/main/resources/assets/mwc/lang/pt_BR.lang
@@ -1066,7 +1066,6 @@ gui.firearmMode=Firearm mode: %s
 gui.firearmMode.semi=Semi
 gui.firearmMode.auto=Auto
 gui.firearmMode.burst=Rajada
-gui.inventoryFull=Inventário Cheio
 gui.currentZoom=Zoom: %s%%
 gui.grenadeExplodes=Explodindo em %s seg
 gui.coolingDown=Cooling down...

--- a/src/main/resources/assets/mwc/lang/tr_TR.lang
+++ b/src/main/resources/assets/mwc/lang/tr_TR.lang
@@ -1055,7 +1055,6 @@ gui.firearmMode=Silah modu: %s
 gui.firearmMode.semi=Yarı otomatik
 gui.firearmMode.auto=Tam otomatik
 gui.firearmMode.burst=Atışlı
-gui.inventoryFull=Envanter dolu
 gui.currentZoom=Yakınlaştırma: %s%%
 gui.grenadeExplodes= %s saniye içinde patlar
 gui.coolingDown=Soğuma...

--- a/src/main/resources/assets/mwc/lang/zh_CN.lang
+++ b/src/main/resources/assets/mwc/lang/zh_CN.lang
@@ -1093,7 +1093,6 @@ gui.firearmMode=枪支模式: %s
 gui.firearmMode.semi=半自动
 gui.firearmMode.auto=全自动
 gui.firearmMode.burst=连发
-gui.inventoryFull=背包已满
 gui.currentZoom=缩放: %s%%
 gui.grenadeExplodes=将于%s秒后爆炸
 gui.coolingDown=冷却中...


### PR DESCRIPTION
## 📝 Description

This is a hotfix for multiple places where items will destroy themselves if the inventory is full.

## 🎯 Goals

The goal of this PR is to prevent the loss of items when the player starts to reload then fills their inventory slot.

## ❌ Non Goals

It is not a goal to clean up any code in this PR.

## 🚦 Testing 

Tested within and outside of dev-env. Seems to work.

## ⏮️ Backwards Compatibility 

Perfectly backwards compatible.

## 📚 Related Issues & Documents

- Fixes #372 
- Fixes #395 

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved code quality for better readability in the `MagazineReloadAspect.java` file.
- **Bug Fixes**
	- Adjusted item handling to drop items instead of preventing unloading with a full inventory, improving gameplay.
	- Fixed issues with fog obscuring vision in optical scopes and weapons destroying magazines/bullets.
- **Documentation**
	- Updated language files in multiple languages to remove the string related to the inventory full message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->