### PR TITLE
Reset FOV on Reload

### DIFF
--- a/src/main/java/com/paneedah/weaponlib/WeaponEventHandler.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponEventHandler.java
@@ -2,7 +2,6 @@ package com.paneedah.weaponlib;
 
 import com.paneedah.mwc.proxies.ClientProxy;
 import com.paneedah.mwc.utils.MWCUtil;
-import com.paneedah.mwc.utils.ModReference;
 import com.paneedah.weaponlib.compatibility.CompatibleExposureCapability;
 import com.paneedah.weaponlib.grenade.PlayerGrenadeInstance;
 import com.paneedah.weaponlib.melee.PlayerMeleeInstance;
@@ -11,7 +10,10 @@ import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.client.event.*;
+import net.minecraftforge.client.event.FOVUpdateEvent;
+import net.minecraftforge.client.event.MouseEvent;
+import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -65,16 +67,16 @@ public class WeaponEventHandler {
 			//fov = instance.isAimed() ? instance.getZoom() : 1f;
 			//fov = compatibility.isFlying(MC.player) ? 1.1f : 1.0f; //instance.isAimed() ? instance.getZoom() : 1f;
 
-		ModReference.LOG.warn("CURRENT STATE: " + instance.state.toString());
+		final WeaponState state = instance.state;
 
 		if (instance.isAimed()
 				&& ClientProxy.renderingPhase == null
-				&& instance.state != WeaponState.TACTICAL_RELOAD
-				&& instance.state != WeaponState.COMPOUND_RELOAD
-				&& instance.state != WeaponState.COMPOUND_RELOAD_EMPTY
-				&& instance.state != WeaponState.COMPOUND_RELOAD_UNLOAD
-				&& instance.state != WeaponState.UNLOAD_PREPARING
-				&& instance.state != WeaponState.LOAD)
+				&& !(state == WeaponState.TACTICAL_RELOAD
+					|| state == WeaponState.COMPOUND_RELOAD
+					|| state == WeaponState.COMPOUND_RELOAD_EMPTY
+					|| state == WeaponState.COMPOUND_RELOAD_UNLOAD
+					|| state == WeaponState.UNLOAD_PREPARING
+					|| state == WeaponState.LOAD))
 			fov = 0.7f;
 
 		if (MC.player.isSprinting())

--- a/src/main/java/com/paneedah/weaponlib/WeaponEventHandler.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponEventHandler.java
@@ -2,6 +2,7 @@ package com.paneedah.weaponlib;
 
 import com.paneedah.mwc.proxies.ClientProxy;
 import com.paneedah.mwc.utils.MWCUtil;
+import com.paneedah.mwc.utils.ModReference;
 import com.paneedah.weaponlib.compatibility.CompatibleExposureCapability;
 import com.paneedah.weaponlib.grenade.PlayerGrenadeInstance;
 import com.paneedah.weaponlib.melee.PlayerMeleeInstance;
@@ -28,9 +29,6 @@ public class WeaponEventHandler {
 
 	@SubscribeEvent
 	public void zoom(FOVUpdateEvent event) {
-		
-		
-		
 		/*
 		 * TODO: if optical zoom is on then
 		 * 			if rendering phase is "renderer viewfinder" then
@@ -40,52 +38,50 @@ public class WeaponEventHandler {
 		 *       else if optical zoom is off
 		 *       	setNewFov(getZoom())
 		 */
-		
-		
-		
 
 		//ItemStack stack = compatibility.getHeldItemMainHand(compatibility.getEntity(event));
 		//ClientModContext modContext = ClientModContext.getContext();
 		PlayerWeaponInstance instance = modContext.getMainHeldWeapon();
 		EntityPlayer clientPlayer = MC.player;
-		if (instance != null) {
-		   
-		    float fov;
-		    if(instance.isAttachmentZoomEnabled()) {
-		    	fov = instance.getWeapon().getADSZoom();
-		    	 if(ClientProxy.renderingPhase == RenderingPhase.RENDER_PERSPECTIVE) {
-		           
-		        	fov = instance.getZoom();
-		        } else {
-		        	
-		            fov = clientPlayer.capabilities.isFlying ? 1.1f : 1.0f;
-		        }
-		    } else {
-		    	 fov = MC.player.capabilities.isFlying ? 1.1f : 1.0f;
-		    	//fov = instance.isAimed() ? instance.getZoom() : 1f;
-		       // fov = compatibility.isFlying(MC.player) ? 1.1f : 1.0f; //instance.isAimed() ? instance.getZoom() : 1f;
-		    }
 
-		   RenderingPhase phase = ClientProxy.renderingPhase;
-		 
-		     if(instance.isAimed() && phase == null) {
-		    	fov = 0.7f;
-		    }
-		     
-		    if(MC.player.isSprinting()) {
-		    	fov *= 1.2;
-		    }
-		    
-		    //fov = 0.3f;
-			event.setNewfov(fov);
-		} else {
-		    SpreadableExposure spreadableExposure = CompatibleExposureCapability.getExposure(MC.player, SpreadableExposure.class);
-            if(spreadableExposure != null && spreadableExposure.getTotalDose() > 0f) {
-                float fov = MC.player.capabilities.isFlying ? 1.1f : 1.0f;
+		if (instance == null) {
+			SpreadableExposure spreadableExposure = CompatibleExposureCapability.getExposure(MC.player, SpreadableExposure.class);
+			if (spreadableExposure != null && spreadableExposure.getTotalDose() > 0f) {
+				float fov = MC.player.capabilities.isFlying ? 1.1f : 1.0f;
 				event.setNewfov(fov);
-            }
+			}
+			return;
 		}
-		
+
+		float fov;
+		if (instance.isAttachmentZoomEnabled()) {
+			if (ClientProxy.renderingPhase == RenderingPhase.RENDER_PERSPECTIVE)
+				fov = instance.getZoom();
+			else
+				fov = clientPlayer.capabilities.isFlying ? 1.1f : 1.0f;
+
+		} else
+			fov = MC.player.capabilities.isFlying ? 1.1f : 1.0f;
+			//fov = instance.isAimed() ? instance.getZoom() : 1f;
+			//fov = compatibility.isFlying(MC.player) ? 1.1f : 1.0f; //instance.isAimed() ? instance.getZoom() : 1f;
+
+		ModReference.LOG.warn("CURRENT STATE: " + instance.state.toString());
+
+		if (instance.isAimed()
+				&& ClientProxy.renderingPhase == null
+				&& instance.state != WeaponState.TACTICAL_RELOAD
+				&& instance.state != WeaponState.COMPOUND_RELOAD
+				&& instance.state != WeaponState.COMPOUND_RELOAD_EMPTY
+				&& instance.state != WeaponState.COMPOUND_RELOAD_UNLOAD
+				&& instance.state != WeaponState.UNLOAD_PREPARING
+				&& instance.state != WeaponState.LOAD)
+			fov = 0.7f;
+
+		if (MC.player.isSprinting())
+			fov *= 1.2f;
+
+		//fov = 0.3f;
+		event.setNewfov(fov);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
@@ -421,10 +421,8 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             } else {
                 if (WeaponAttachmentAspect.getActiveAttachment(AttachmentCategory.MAGAZINE, instance) == null) {
                     ItemStack nextAttachment = getNextBestMagazineStack(instance);
-                    if (instance.getWeapon().getRenderer().getBuilder().isHasLoadEmpty() && nextAttachment != null && Tags.getAmmo(nextAttachment) == 0) {
-                        instance.setAimed(false);
+                    if (instance.getWeapon().getRenderer().getBuilder().isHasLoadEmpty() && nextAttachment != null && Tags.getAmmo(nextAttachment) == 0)
                         instance.getWeapon().getRenderer().setShouldDoEmptyVariant(true);
-                    }
 
                     stateManager.changeState(this, instance, WeaponState.AWAIT_FURTHER_LOAD_INSTRUCTIONS, WeaponState.READY);
                 } else {
@@ -435,22 +433,19 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
 
                     instance.markReloadDirt();
                     instance.markMagSwapReady();
-
                     if (instance.getAmmo() == 0) {
                         if (nextAttachment != null)
                             instance.getWeapon().getRenderer().setMagicMag(instance, nextAttachment, WeaponState.COMPOUND_RELOAD_EMPTY);
+
                         else
 							return;
 
-                        instance.setAimed(false);
                         stateManager.changeState(this, instance, WeaponState.COMPOUND_RELOAD_EMPTY);
                     } else {
                         if (nextAttachment != null)
                             instance.getWeapon().getRenderer().setMagicMag(instance, nextAttachment, WeaponState.COMPOUND_RELOAD);
                         else
 							return;
-
-                        instance.setAimed(false);
                         instance.setIsAwaitingCompoundInstructions(true);
                         stateManager.changeState(this, instance, WeaponState.COMPOUND_REQUESTED, WeaponState.READY);
                     }
@@ -467,11 +462,10 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             instance.getWeapon().getRenderer().compoundReload = false;
             instance.setLoadAfterUnloadEnabled(false);
 
+
             ItemAttachment<Weapon> currentMagazine = modContext.getAttachmentAspect().getActiveAttachment(instance, AttachmentCategory.MAGAZINE);
-            if (instance.getWeapon().getRenderer().getBuilder().isHasUnloadEmpty() && currentMagazine != null && instance.getAmmo() == 0) {
-                instance.setAimed(false);
+            if (instance.getWeapon().getRenderer().getBuilder().isHasUnloadEmpty() && currentMagazine != null && instance.getAmmo() == 0)
                 instance.getWeapon().getRenderer().setShouldDoEmptyVariant(true);
-            }
 
             stateManager.changeState(this, instance, WeaponState.UNLOAD, WeaponState.ALERT);
         }
@@ -640,7 +634,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             p.setStatus(Status.DENIED);
         else if (attachment instanceof ItemMagazine && !player.isCreative()) {
             ItemStack attachmentItemStack = ((ItemMagazine) attachment).create(originalAmmo);
-            instance.setAimed(false);
             if (!player.inventory.addItemStackToInventory(attachmentItemStack))
                 LOG.error("Cannot add attachment " + attachment + " for " + instance + "back to the inventory");
             p.setStatus(Status.GRANTED);
@@ -682,7 +675,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
         }
 
         if (!compatibleMagazines.isEmpty()) {
-            weaponInstance.setAimed(false);
             ItemAttachment<Weapon> existingMagazine = WeaponAttachmentAspect.getActiveAttachment(AttachmentCategory.MAGAZINE, weaponInstance);
             int ammo = Tags.getAmmo(weaponItemStack);
             if (existingMagazine == null) {
@@ -702,7 +694,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             // Update permit instead: CHANNEL.sendTo(new ReloadMessage(weapon, ReloadMessage.Type.LOAD, newMagazine, ammo), (EntityPlayerMP) player);
             weaponInstance.setAmmo(ammo);
         } else if (!compatibleBullets.isEmpty() && (consumedAmount = MWCUtil.consumeItemsFromPlayerInventory(compatibleBullets, Math.min(weapon.getMaxBulletsPerReload(), weapon.getAmmoCapacity() - weaponInstance.getAmmo()), player)) != 0) {
-            weaponInstance.setAimed(false);
             int ammo = weaponInstance.getAmmo() + consumedAmount;
             Tags.setAmmo(weaponItemStack, ammo);
             // Update permit instead CHANNEL.sendTo(new ReloadMessage(weapon, ammo), (EntityPlayerMP) player);
@@ -711,7 +702,6 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
                 weaponInstance.setLoadIterationCount(consumedAmount);
             player.world.playSound(player instanceof EntityPlayer ? (EntityPlayer) player : null, player.posX, player.posY, player.posZ, weapon.getReloadSound(), player.getSoundCategory(), 1.0F, 1.0F);
         } else if (consumed) {
-            weaponInstance.setAimed(false);
             Tags.setAmmo(weaponItemStack, weapon.builder.ammoCapacity);
             // Update permit instead: CHANNEL.sendTo(new ReloadMessage(weapon, weapon.builder.ammoCapacity), (EntityPlayerMP) player);
             weaponInstance.setAmmo(weapon.builder.ammoCapacity);

--- a/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponReloadAspect.java
@@ -421,8 +421,10 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             } else {
                 if (WeaponAttachmentAspect.getActiveAttachment(AttachmentCategory.MAGAZINE, instance) == null) {
                     ItemStack nextAttachment = getNextBestMagazineStack(instance);
-                    if (instance.getWeapon().getRenderer().getBuilder().isHasLoadEmpty() && nextAttachment != null && Tags.getAmmo(nextAttachment) == 0)
+                    if (instance.getWeapon().getRenderer().getBuilder().isHasLoadEmpty() && nextAttachment != null && Tags.getAmmo(nextAttachment) == 0) {
+                        instance.setAimed(false);
                         instance.getWeapon().getRenderer().setShouldDoEmptyVariant(true);
+                    }
 
                     stateManager.changeState(this, instance, WeaponState.AWAIT_FURTHER_LOAD_INSTRUCTIONS, WeaponState.READY);
                 } else {
@@ -433,19 +435,22 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
 
                     instance.markReloadDirt();
                     instance.markMagSwapReady();
+
                     if (instance.getAmmo() == 0) {
                         if (nextAttachment != null)
                             instance.getWeapon().getRenderer().setMagicMag(instance, nextAttachment, WeaponState.COMPOUND_RELOAD_EMPTY);
-
                         else
 							return;
 
+                        instance.setAimed(false);
                         stateManager.changeState(this, instance, WeaponState.COMPOUND_RELOAD_EMPTY);
                     } else {
                         if (nextAttachment != null)
                             instance.getWeapon().getRenderer().setMagicMag(instance, nextAttachment, WeaponState.COMPOUND_RELOAD);
                         else
 							return;
+
+                        instance.setAimed(false);
                         instance.setIsAwaitingCompoundInstructions(true);
                         stateManager.changeState(this, instance, WeaponState.COMPOUND_REQUESTED, WeaponState.READY);
                     }
@@ -462,10 +467,11 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             instance.getWeapon().getRenderer().compoundReload = false;
             instance.setLoadAfterUnloadEnabled(false);
 
-
             ItemAttachment<Weapon> currentMagazine = modContext.getAttachmentAspect().getActiveAttachment(instance, AttachmentCategory.MAGAZINE);
-            if (instance.getWeapon().getRenderer().getBuilder().isHasUnloadEmpty() && currentMagazine != null && instance.getAmmo() == 0)
+            if (instance.getWeapon().getRenderer().getBuilder().isHasUnloadEmpty() && currentMagazine != null && instance.getAmmo() == 0) {
+                instance.setAimed(false);
                 instance.getWeapon().getRenderer().setShouldDoEmptyVariant(true);
+            }
 
             stateManager.changeState(this, instance, WeaponState.UNLOAD, WeaponState.ALERT);
         }
@@ -634,6 +640,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             p.setStatus(Status.DENIED);
         else if (attachment instanceof ItemMagazine && !player.isCreative()) {
             ItemStack attachmentItemStack = ((ItemMagazine) attachment).create(originalAmmo);
+            instance.setAimed(false);
             if (!player.inventory.addItemStackToInventory(attachmentItemStack))
                 LOG.error("Cannot add attachment " + attachment + " for " + instance + "back to the inventory");
             p.setStatus(Status.GRANTED);
@@ -675,6 +682,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
         }
 
         if (!compatibleMagazines.isEmpty()) {
+            weaponInstance.setAimed(false);
             ItemAttachment<Weapon> existingMagazine = WeaponAttachmentAspect.getActiveAttachment(AttachmentCategory.MAGAZINE, weaponInstance);
             int ammo = Tags.getAmmo(weaponItemStack);
             if (existingMagazine == null) {
@@ -694,6 +702,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
             // Update permit instead: CHANNEL.sendTo(new ReloadMessage(weapon, ReloadMessage.Type.LOAD, newMagazine, ammo), (EntityPlayerMP) player);
             weaponInstance.setAmmo(ammo);
         } else if (!compatibleBullets.isEmpty() && (consumedAmount = MWCUtil.consumeItemsFromPlayerInventory(compatibleBullets, Math.min(weapon.getMaxBulletsPerReload(), weapon.getAmmoCapacity() - weaponInstance.getAmmo()), player)) != 0) {
+            weaponInstance.setAimed(false);
             int ammo = weaponInstance.getAmmo() + consumedAmount;
             Tags.setAmmo(weaponItemStack, ammo);
             // Update permit instead CHANNEL.sendTo(new ReloadMessage(weapon, ammo), (EntityPlayerMP) player);
@@ -702,6 +711,7 @@ public class WeaponReloadAspect implements Aspect<WeaponState, PlayerWeaponInsta
                 weaponInstance.setLoadIterationCount(consumedAmount);
             player.world.playSound(player instanceof EntityPlayer ? (EntityPlayer) player : null, player.posX, player.posY, player.posZ, weapon.getReloadSound(), player.getSoundCategory(), 1.0F, 1.0F);
         } else if (consumed) {
+            weaponInstance.setAimed(false);
             Tags.setAmmo(weaponItemStack, weapon.builder.ammoCapacity);
             // Update permit instead: CHANNEL.sendTo(new ReloadMessage(weapon, weapon.builder.ammoCapacity), (EntityPlayerMP) player);
             weaponInstance.setAmmo(weapon.builder.ammoCapacity);


### PR DESCRIPTION
## 📝 Description

This PR aims to fix issue #377.
The problem was that when you started to reload, it wouldn't correctly reset your FOV.

## 🎯 Goals

Make the screen zoom back out accordingly while reloading.

## ❌ Non Goals

It is not a goal of this PR to clean up code or fix any other reload issue

## 🚦 Testing 

Tested within and outside of dev-env.

## ⏮️ Backwards Compatibility 

Perfectly backwards compatible.

## 📚 Related Issues & Documents

- #377

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the zoom functionality in the game, including more conditions for zoom behavior and refined field of view calculations for enhanced player experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->