### PR TITLE
Stop blocks from ticking randomly

### DIFF
--- a/src/main/java/com/paneedah/mwc/bases/BlockBase.java
+++ b/src/main/java/com/paneedah/mwc/bases/BlockBase.java
@@ -14,6 +14,7 @@ public class BlockBase extends Block {
         super(Material.ROCK);
         setRegistryName(registryName);
         setTranslationKey(registryName);
+        setTickRandomly(false);
 
         setHardness(6F);
         setResistance(15F);

--- a/src/main/java/com/paneedah/mwc/bases/OreBase.java
+++ b/src/main/java/com/paneedah/mwc/bases/OreBase.java
@@ -18,6 +18,7 @@ public class OreBase extends BlockOre {
     public OreBase(String registryName) {
         setRegistryName(registryName);
         setTranslationKey(registryName);
+        setTickRandomly(false);
 
         setHardness(6F);
         setResistance(15F);


### PR DESCRIPTION
## 📝 Description

Adds setTickRandomly(false); in BlockBase.

## 🎯 Goals

Improve performance when MWC ores are ticked, or more like not ticked

## ❌ Non Goals

Smeagle the mod 

## 🚦 Testing 

Soon™️ 

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.12.2/

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed