### PR TITLE
Updates to bullet display HUD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows to [Ragnarök Versioning Convention](https://gist.github.com/JustDesoroxxx/5d4a45785ce19a6653ba99f72325c703).
 
+## [UNRELEASED] Modern Warfare Cubed Version 0.2 Changelog
+
+### Changed
+
+- Press [B] to change fire mode now only appears when the weapon has multiple fire modes
+- Magazines now show bullet count in the magazine the same way guns do, instead of a white text in the top-right corner
+- Crosshair will now appear when holding a magazine
+
 ## Modern Warfare Cubed Version 0.1.4 Changelog - 2024-03-18
 
 ### Warning

--- a/src/main/java/com/paneedah/weaponlib/CustomGui.java
+++ b/src/main/java/com/paneedah/weaponlib/CustomGui.java
@@ -27,6 +27,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -149,7 +150,7 @@ public class CustomGui extends Gui {
 		}
 	    
 		
-		if(event.getType() == RenderGameOverlayEvent.ElementType.HELMET && MC.player.isRiding() && MC.player.getRidingEntity() instanceof EntityVehicle) {
+		if(event.getType() == HELMET && MC.player.isRiding() && MC.player.getRidingEntity() instanceof EntityVehicle) {
 			
 			
 			
@@ -159,7 +160,7 @@ public class CustomGui extends Gui {
 	}
 	
 	public void handleHelmetHUD(RenderGameOverlayEvent.Pre event) {
-		if(event.getType() == RenderGameOverlayEvent.ElementType.HELMET) {
+		if(event.getType() == HELMET) {
 	        
 			ItemStack helmetStack = MC.player.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
 			if(helmetStack != null && MC.gameSettings.thirdPersonView == 0 && helmetStack.getItem() instanceof CustomArmor) {
@@ -207,31 +208,6 @@ public class CustomGui extends Gui {
 			}
 		}
 	}
-
-	
-	public void handleModificationHUD(RenderGameOverlayEvent.Pre event, PlayerWeaponInstance weaponInstance, double scaledWidth,
-			double scaledHeight) {
-		if (isInAltModifyingState(weaponInstance) || isInModifyingState(weaponInstance)) {
-			//GlStateManager.alphaFunc(GL11.GL_GREATER, 0);
-			ModificationGUI.getInstance().render(modContext);
-			//GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1f);
-			//GlStateManager.enableBlend();
-			//GlStateManager.alphaFunc(GL11.GL_GREATER, 0);
-			//GUIRenderHelper.drawColoredRectangle(20, 200, 128, 125, 0.05, ColorPalette.BLACK);
-
-		} else {
-			if(ModernConfigManager.enableAmmoCounter) {
-				ModernConfigManager.enableOpenDoorDisplay = true;
-			} else {
-				ModernConfigManager.enableOpenDoorDisplay = false;
-			}
-
-			if(ModernConfigManager.enableAmmoCounter) {
-				handleAmmoCounter(event, weaponInstance, scaledWidth, scaledHeight);
-			}
-			event.setCanceled(true);
-		}
-	}
 	
 	// Ammo counter spec
 	public static final int AMMO_COUNTER_WIDTH = 256;
@@ -271,7 +247,8 @@ public class CustomGui extends Gui {
 	public static final double KEY_NAME_OFFSET_FIREMODE_INDICATOR_MULTIPLIER = 1.75;
 	public static final double CURRENT_AMMO_WIDTH_MULTIPLIER = 2.0;
 	public static final double TOTAL_AMMO_STRING_SCALE = 6.625;
-	
+
+	@Deprecated // Use drawAmmoCounter instead
 	public void handleAmmoCounter(RenderGameOverlayEvent.Pre event, PlayerWeaponInstance weaponInstance, double scaledWidth, double scaledHeight) {
 		final int AMMO_COUNTER_X_POS = 256 + ModernConfigManager.ammoCounterX;
 		final int AMMO_COUNTER_Y_POS = 128 + ModernConfigManager.ammoCounterY;
@@ -444,16 +421,13 @@ public class CustomGui extends Gui {
 
 	@SubscribeEvent
 	public final void onRenderCrosshair(RenderGameOverlayEvent.Pre event) {
-		
-		if (event.getType() != RenderGameOverlayEvent.ElementType.CROSSHAIRS || MC.player.isSpectator()) {
+		if (event.getType() != CROSSHAIRS || MC.player.isSpectator()) {
 			return;
 		}
-		
-		
 
 		ItemStack itemStack = MC.player.getHeldItemMainhand();
 
-		if(itemStack == null) {
+		if (itemStack == null) {
 			return;
 		}
 		
@@ -464,18 +438,11 @@ public class CustomGui extends Gui {
 
 		PlayerWeaponInstance weaponInstance = modContext.getMainHeldWeapon();
 
-		
-		
-		
 		if(weaponInstance != null) {
-		    
 			Weapon weaponItem = (Weapon) itemStack.getItem();
-
 			String crosshair = weaponItem != null ? weaponItem.getCrosshair(weaponInstance) : null;
+
 			if(crosshair != null) {
-
-
-
 				MC.entityRenderer.setupOverlayRendering();
 
 				GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
@@ -485,29 +452,125 @@ public class CustomGui extends Gui {
 
 				MC.renderEngine.bindTexture(new ResourceLocation(crosshair));
 
-                   
-                handleModificationHUD(event, modContext.getMainHeldWeapon(), width, height);
+				if (isInAltModifyingState(weaponInstance) || isInModifyingState(weaponInstance)) {
+					//GlStateManager.alphaFunc(GL11.GL_GREATER, 0);
+					ModificationGUI.getInstance().render(modContext);
+					//GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1f);
+					//GlStateManager.enableBlend();
+					//GlStateManager.alphaFunc(GL11.GL_GREATER, 0);
+					//GUIRenderHelper.drawColoredRectangle(20, 200, 128, 125, 0.05, ColorPalette.BLACK);
+
+				} else {
+					ModernConfigManager.enableOpenDoorDisplay = ModernConfigManager.enableAmmoCounter;
+					drawAmmoCounter(fontRender, width, height, itemStack.getItem());
+				}
+
                 handleOpenDoorHUD(event, width, height);
-
-					
+				event.setCanceled(true);
 			}
+
 		} else if(itemStack.getItem() instanceof ItemMagazine) {
-
-			MC.entityRenderer.setupOverlayRendering();
-			int color = 0xFFFFFF;
-
-			String messageText;
-			messageText = getDefaultMagazineMessage(itemStack);
-
-			int x = getStatusBarXPosition(width, messageText, fontRender);
-			int y = getStatusBarYPosition(height);
-
-			fontRender.drawStringWithShadow(messageText, x, y, color);
-			event.setCanceled(true);
+			drawAmmoCounter(fontRender, width, height, itemStack.getItem());
 		}
 	}
-	
-	
+
+	public void drawAmmoCounter(FontRenderer fr, int width, int height, Item item) {
+		if (!ModernConfigManager.enableAmmoCounter) return;
+
+		getFontRenderer();
+
+		GlStateManager.enableBlend();
+		GlStateManager.pushMatrix();
+
+		final int AMMO_COUNTER_X_POS = 256 + ModernConfigManager.ammoCounterX;
+		final int AMMO_COUNTER_Y_POS = 128 + ModernConfigManager.ammoCounterY;
+		final double AMMO_COUNTER_SIZE = ModernConfigManager.ammoCounterSize;
+
+		GlStateManager.translate((width - AMMO_COUNTER_X_POS * AMMO_COUNTER_SIZE), (height - AMMO_COUNTER_Y_POS * AMMO_COUNTER_SIZE), 0);
+		GlStateManager.scale(AMMO_COUNTER_SIZE, AMMO_COUNTER_SIZE, AMMO_COUNTER_SIZE);
+		MC.getTextureManager().bindTexture(AMMO_COUNTER_TEXTURES);
+
+		if (ModernConfigManager.enableAmmoCounterBackground) {
+			if (ModernConfigManager.ammoCounterBackgroundReverse) {
+				GlStateManager.enableBlend();
+				GlStateManager.pushMatrix();
+				GlStateManager.scale(-1, 1, 1);
+				drawTexturedModalRect(-90, 0, 0, 0, -AMMO_COUNTER_WIDTH, AMMO_COUNTER_HEIGHT);
+				GlStateManager.popMatrix();
+			} else
+				drawTexturedModalRect(0, 0, 0, 0, AMMO_COUNTER_WIDTH, AMMO_COUNTER_HEIGHT);
+		}
+
+		String totalCapacityString, currentAmmoString;
+		int firemode;
+		int totalCapacity = 0;
+		int currentAmmo = 0;
+
+		if (item instanceof ItemMagazine) {
+			totalCapacity = ((ItemMagazine) item).getCapacity();
+			currentAmmo = Tags.getAmmo(MC.player.getHeldItemMainhand());
+
+		} else if (item instanceof Weapon) {
+			final PlayerWeaponInstance weaponInstance = modContext.getMainHeldWeapon();
+			final ItemMagazine magazine = (ItemMagazine) WeaponAttachmentAspect.getActiveAttachment(AttachmentCategory.MAGAZINE, weaponInstance);
+			final String keyNameString = String.format(BRACKET_FORMATTER, KeyBindings.fireModeKey.getDisplayName());
+			final double keyNameOffset = getFontRenderer().getStringWidth(keyNameString);
+
+			switch (weaponInstance.getMaxShots()) {
+				case Integer.MAX_VALUE:
+					firemode = Weapon.FIREMODE_AUTO;
+					break;
+				case 1:
+					firemode = Weapon.FIREMODE_SINGLE;
+					break;
+				default:
+					firemode = Weapon.FIREMODE_BURST;
+					break;
+			}
+
+			totalCapacity = magazine != null ? magazine.getCapacity() : weaponInstance.getWeapon().getAmmoCapacity();
+			currentAmmo = weaponInstance.getAmmo();
+
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(AMMO_COUNTER_WIDTH - FIREMODE_INDICATOR_X_OFFSET - (keyNameOffset * KEY_NAME_OFFSET_FIREMODE_INDICATOR_MULTIPLIER), FIREMODE_INDICATOR_Y_OFFSET, 0);
+			GlStateManager.scale(FIREMODE_INDICATOR_SCALE, FIREMODE_INDICATOR_SCALE, FIREMODE_INDICATOR_SCALE);
+			GlStateManager.enableBlend();
+			drawTexturedModalRect(0, 0, FIREMODE_INDICATOR_U_OFFSET + FIREMODE_INDICATOR_U_WIDTH * (Weapon.FIREMODE_AUTO - firemode), FIREMODE_INDICATOR_V_HEIGHT, FIREMODE_INDICATOR_U_WIDTH, FIREMODE_INDICATOR_U_WIDTH);
+			GlStateManager.popMatrix();
+
+			if (((Weapon)item).builder.getMaxShots().size() > 1)
+				drawScaledString(FONT_RENDERER, keyNameString, FIREMODE_KEY_X_STRING_OFFSET - keyNameOffset, FIREMODE_KEY_Y_STRING_OFFSET, FIREMODE_KEY_SCALE, FlatUIColors.BRIGHT_YARROW);
+		}
+
+		if (totalCapacity == 0) {
+			totalCapacityString = "-";
+			currentAmmoString = "-";
+		} else {
+			totalCapacityString = String.valueOf(totalCapacity);
+			currentAmmoString = String.valueOf((currentAmmo == 0 && item instanceof Weapon ? "-" : currentAmmo));
+		}
+
+		final String weaponName = new TextComponentTranslation(LangTools.formatName(item.getTranslationKey())).getFormattedText();
+		final String bottomString = String.format("  %s  | %s%s", TextFormatting.GRAY, TextFormatting.WHITE, totalCapacityString);
+
+		double totalLength = 0;
+		if (bottomString.length() > AMMO_COUNTER_WEAPON_NAME_DOWNSCALE_THRESHOLD) {
+			final int adjLength = bottomString.length() - AMMO_COUNTER_WEAPON_NAME_DOWNSCALE_THRESHOLD;
+			totalLength = adjLength * WEAPON_NAME_DOWNSCALE_MULTIPLIER;
+		}
+
+		drawScaledString(FONT_RENDERER, weaponName, WEAPON_STRING_X_OFFSET - FONT_RENDERER.getStringWidth(weaponName), - FONT_RENDERER.FONT_HEIGHT, WEAPON_STRING_SCALE, FlatUIColors.BRIGHT_YARROW);
+
+		if(item instanceof Weapon && BalancePackManager.isWeaponDisabled((Weapon)item)) {
+			GUIRenderHelper.drawScaledString("Disabled", DISABLED_STRING_X_OFFSET - totalLength, DISABLED_STRING_Y_OFFSET, DISABLED_STRING_SCALE, FlatUIColors.POMEGRANATE);
+		} else {
+			drawScaledString(fr, weaponName, WEAPON_STRING_X_OFFSET - fr.getStringWidth(weaponName), - fr.FONT_HEIGHT, WEAPON_STRING_SCALE, FlatUIColors.BRIGHT_YARROW);
+			drawScaledString(fr, currentAmmoString, TOTAL_AMMO_COUNT_STRING_X_OFFSET - fr.getStringWidth(currentAmmoString) * CURRENT_AMMO_WIDTH_MULTIPLIER, CURRENT_AMMO_STRING_Y_OFFSET, CURRENT_AMMO_STRING_SCALE, FlatUIColors.BRIGHT_YARROW);
+			drawScaledString(fr, bottomString, CURRENT_AMMO_COUNT_STRING_X_OFFSET, TOTAL_AMMO_STRING_SCALE, AMMO_TOTAL_STRING_SCALE);
+		}
+
+		GlStateManager.popMatrix();
+	}
 
 	public void drawScaledString(FontRenderer fr, String str, double x, double y, double scale, int color) {
 		


### PR DESCRIPTION
## 📝 Description

This PR is all about the `Ammo HUD` and the bottom-right ammo counter display, improvements and small bug fixes.

## 🎯 Goals

- Create a universal `drawAmmoCounter` method that works with both guns and magazines
- Make magazines draw their ammo counter like guns, not a white text in the top-right corner
- Only display the `[B]` (change firing mode) if there's multiple modes to choose from
- Show the crosshair when holding a magazine (idfk why it doesn't alr do that)

## ❌ Non Goals

It is not a goal to update old methods and try to do stupid shit to them to get them to work.

It is not a goal to update anything that isn't simply visual / in the HUD.

## 🚦 Testing 

This has been tested within and outside of dev-env.
Tested all HUD related items such as open door, combinations of magazines and guns, and more.

## ⏮️ Backwards Compatibility 

Perfectly backwards compatible and won't break anything. Old method has been marked as `@Deprecated` and should be removed in the near future.

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

### Original Display:
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/76911089/5db9c444-0196-4c4f-8384-16f3611c3ea6)

### New:
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/76911089/1a9e5127-6a5c-4277-9b10-ccb65c0e4ad1)
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/76911089/f367eeb9-dcf5-4346-8ed1-09225956e565)
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/76911089/f19e4598-ae7e-4fd4-9332-5fddb273dd50)

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed
