### PR TITLE
Port P220 from VMW

### DIFF
--- a/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
+++ b/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
@@ -1,0 +1,485 @@
+package com.paneedah.mwc.items.guns;
+
+import java.util.Arrays;
+
+import net.minecraft.item.Item;
+
+import org.lwjgl.opengl.GL11;
+
+import com.paneedah.mwc.MWC;
+import com.paneedah.mwc.models.*;
+import com.paneedah.mwc.proxies.CommonProxy;
+import com.paneedah.mwc.weapons.Attachments;
+import com.paneedah.mwc.weapons.AuxiliaryAttachments;
+import com.paneedah.mwc.weapons.Magazines;
+import com.paneedah.weaponlib.*;
+import com.paneedah.weaponlib.animation.Transform;
+import com.paneedah.weaponlib.animation.Transition;
+import com.paneedah.weaponlib.compatibility.RecoilParam;
+import com.paneedah.weaponlib.config.BalancePackManager.GunConfigurationGroup;
+import net.minecraft.item.Item;
+import org.lwjgl.opengl.GL11;
+
+import java.util.Arrays;
+
+public class P220Factory implements GunFactory {
+
+	public Item createGun(CommonProxy commonProxy) {
+		return new Weapon.Builder()
+		.withModId(ModernWarfareMod.MODID)
+		.withName("P220")
+//		.withAmmo(CommonProxy.M9Mag)
+//		.withAmmoCapacity(10)
+		.withFireRate(0.6f)
+		.withRecoil(6f)
+		.withZoom(0.9f)
+		.withMaxShots(1, Integer.MAX_VALUE)
+		.withShootSound("P225")
+		.withSilencedShootSound("silencer")
+		.withReloadSound("PistolReload")
+		.withUnloadSound("Unload")
+		.withReloadingTime(50)
+		.withCrosshair("gun")
+		.withCrosshairRunning("Running")
+		.withCrosshairZoomed("Sight")
+		.withFlashIntensity(1f)
+		.withFlashScale(() -> 0.5f)
+		.withFlashOffsetX(() -> 0.2f)
+		.withFlashOffsetY(() -> 0.1f)
+		.withConfigGroup(GunConfigurationGroup.RIFLES)
+    .withRecoilParam(new RecoilParam( // Recoil param
+                        // The weapon power
+                        15.0,
+                        // Muzzle climb divisor
+                        15.75,
+                        // "Stock Length"
+                        50.0,
+                        // Recovery rate from initial shot
+                        0.4,
+                        // Recovery rate @ "stock"
+                        0.3125,
+                        // Recoil rotation (Y)
+                        0.0,
+                        // Recoil rotation (Z)
+                        0.0,
+                        // Ads similarity divisor
+                        1.0
+                ))
+		.withCompatibleAttachment(AuxiliaryAttachments.P225Top, true, (model) -> {
+//			GL11.glTranslatef(0.1F, -0.5F, -1F);
+//			GL11.glRotatef(45F, 0f, 1f, 0f);
+//			GL11.glScaled(0.55F, 0.55F, 0.55F);
+		})
+		.withCompatibleAttachment(Magazines.M9BerettaMag, (model) -> {
+			GL11.glTranslatef(0F, 0F, 0.1F);
+			})
+		.withCompatibleAttachment(Attachments.Laser, (p, s) -> {
+			GL11.glTranslatef(0.01F, -0.7F, -2.2F);
+			GL11.glScaled(1.1F, 1.1F, 1.1F);
+			GL11.glRotatef(-90F, 0f, 0f, -4f);
+		})
+		.withCompatibleAttachment(Attachments.Silencer9mm, (model) -> {
+			GL11.glTranslatef(-0.25F, -1.2F, -4.6F);
+			GL11.glScaled(1.5F, 1.5F, 1.5F);
+		})
+		.withTextureNames("P225", "Electric")
+		.withRenderer(new WeaponRenderer.Builder()
+			.withModel(new P220())
+			.withEntityPositioning(itemStack -> {
+				GL11.glScaled(0.4F, 0.4F, 0.4F);
+				GL11.glRotatef(-90F, 0f, 0f, 4f);
+			})
+			.withInventoryPositioning(itemStack -> {
+				GL11.glScaled(0.35F, 0.35F, 0.35F);
+				GL11.glTranslatef(0, 0.8f, 0);
+				GL11.glRotatef(-120F, -0.5f, 7f, 3f);
+			})
+			.withThirdPersonPositioning((renderContext) -> {
+				GL11.glScaled(0.5F, 0.5F, 0.5F);
+				GL11.glTranslatef(-1.8F, -1F, 2F);
+				GL11.glRotatef(-45F, 0f, 1f, 0f);
+				GL11.glRotatef(70F, 1f, 0f, 0f);
+				})
+
+
+			.withFirstPersonPositioning((renderContext) -> {
+				GL11.glTranslatef(0.1F, -0.5F, -1F);
+				GL11.glRotatef(45F, 0f, 1f, 0f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
+				})
+
+			.withFirstPersonPositioningRecoiled((renderContext) -> {
+				GL11.glTranslatef(0F, -0.6F, -1.1F);
+				GL11.glRotatef(45F, 0f, 1f, 0f);
+				GL11.glRotatef(-10F, 1f, 0f, 0f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
+				})
+
+			.withFirstPersonPositioningCustomRecoiled(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
+				GL11.glTranslatef(0F, 0F, 0.5F);
+//				GL11.glRotatef(45F, 0f, 1f, 0f);
+//				GL11.glScaled(0.55F, 0.55F, 0.55F);
+				})
+
+
+			.withFirstPersonPositioningCustomZoomingRecoiled(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
+				GL11.glTranslatef(0F, 0F, 0.5F);
+//				GL11.glRotatef(45F, 0f, 1f, 0f);
+//				GL11.glScaled(0.55F, 0.55F, 0.55F);
+				})
+
+			.withFirstPersonPositioningCustomRecoiled(Magazines.M9BerettaMag, (renderContext) -> {})
+
+			.withFirstPersonPositioningCustomZoomingRecoiled(Magazines.M9BerettaMag, (renderContext) -> {})
+
+			.withFirstPersonPositioningZoomingRecoiled((renderContext) -> {
+				GL11.glTranslatef(-0.3F, -0.4F, -0.5F);
+				GL11.glRotatef(45F, 0f, 1f, 0f);
+				GL11.glRotatef(-4F, 1f, 0f, 0f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+				// Zoom
+				GL11.glTranslatef(0.31F, -1.34f, 1.5f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+			/*	// ACOG Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), ModernWarfareMod.ACOG)) {
+					//System.out.println("Position me for Acog");
+					GL11.glTranslatef(0F, 0.3f, 1f);
+				} */
+
+				// Reflex Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Reflex)) {
+					//System.out.println("Position me for Reflex");
+					GL11.glTranslatef(0F, 0.5f, 0.7f);
+				} 
+
+				// Holo Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Holo2)) {
+					//System.out.println("Position me for Holo");
+					GL11.glTranslatef(1.38F, -1.115f, 3.2f);
+				} 
+
+				// Everything else
+				else {
+					GL11.glTranslatef(1.373F, -1.34f, 2.4f);
+				}
+
+
+				})
+
+			//.withFirstPersonCustomRecoiled(CommonProxy.Glock21Mag, (p, itemStack) -> {})
+
+			.withFirstPersonCustomPositioning(Magazines.M9BerettaMag, (renderContext) -> {})
+
+			.withFirstPersonCustomPositioning(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
+				if(renderContext.getWeaponInstance().getAmmo() == 0) {
+					GL11.glTranslatef(0F, 0F, 0.5F);
+				}
+			})
+
+			.withFirstPersonPositioningReloading(
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glTranslatef(-0.6F, -0.6F, -0.6F);
+						GL11.glRotatef(0F, 0f, 1f, 0f);
+						GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+						GL11.glRotatef(-60F, 1f, 0f, 0f);
+						GL11.glRotatef(-10F, 0f, 0f, 1f);
+						GL11.glTranslatef(1F, -1.2F, 0F);
+					}, 250, 500),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glTranslatef(-0.4F, -0.2F, -0.3F);
+						GL11.glRotatef(0F, 0f, 1f, 0f);
+						GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+						GL11.glRotatef(-30F, 1f, 0f, 0f);
+						GL11.glRotatef(-10F, 0f, 0f, 1f);
+						GL11.glTranslatef(1F, -1.2F, 0F);
+					}, 250, 1000),
+
+				new Transition((renderContext) -> { // Reload position
+					GL11.glTranslatef(-0.4F, -0.2F, -0.3F);
+					GL11.glRotatef(0F, 0f, 1f, 0f);
+					GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+					GL11.glRotatef(-30F, 1f, 0f, 0f);
+					GL11.glRotatef(-10F, 0f, 0f, 1f);
+					GL11.glTranslatef(1F, -1.2F, 0F);
+				}, 50, 0)
+			)
+
+			.withFirstPersonPositioningUnloading(
+				new Transition((renderContext) -> { // Reload position
+					GL11.glTranslatef(-0.6F, -0.6F, -0.6F);
+					GL11.glRotatef(0F, 0f, 1f, 0f);
+					GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+					GL11.glRotatef(-60F, 1f, 0f, 0f);
+					GL11.glRotatef(-10F, 0f, 0f, 1f);
+					GL11.glTranslatef(1F, -1.2F, 0F);
+				}, 150, 50),
+				new Transition((renderContext) -> { // Reload position
+					GL11.glTranslatef(-0.6F, -0.6F, -0.6F);
+					GL11.glRotatef(0F, 0f, 1f, 0f);
+					GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+					GL11.glRotatef(-60F, 1f, 0f, 0f);
+					GL11.glRotatef(-10F, 0f, 0f, 1f);
+					GL11.glTranslatef(1F, -1.2F, 0F);
+				}, 150, 50)
+			)
+
+			.withFirstPersonCustomPositioningUnloading(Magazines.M9BerettaMag,
+				new Transition((renderContext) -> {
+//					GL11.glTranslatef(0.2F, 0.5F, -0.2F);
+//					GL11.glRotatef(-20F, 1f, 0f, 0f);
+////					GL11.glScaled(0.55F, 0.55F, 0.55F);
+////					GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0.05F, 1.3F, 0.4F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					//GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000)
+					)
+
+			.withFirstPersonCustomPositioningReloading(Magazines.M9BerettaMag,
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0.05F, 1.3F, 0.4F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					//GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+//					GL11.glTranslatef(0.5F, 0F, -0.2F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+//					GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+					/*GL11.glTranslatef(0.25F, -0.32F, -0.2F);
+					GL11.glRotatef(45F, 0f, 1f, 0f);
+					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					GL11.glTranslatef(-0.4F, -0.8F, 0.9F);*/
+				}, 250, 1000)
+					)
+
+
+			.withFirstPersonCustomPositioningUnloading(AuxiliaryAttachments.P225Top.getRenderablePart(),
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0F, 0F, 0.5F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					//GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0F, 0F, 0.5F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					//GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000)
+					)
+
+			.withFirstPersonCustomPositioningReloading(AuxiliaryAttachments.P225Top.getRenderablePart(),
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0F, 0F, 0.5F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+					//GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+					GL11.glTranslatef(0F, 0F, 0.5F);
+//					GL11.glRotatef(0F, 0f, 1f, 0f);
+//					GL11.glScaled(0.55F, 0.55F, 0.55F);
+//					GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000),
+				new Transition((renderContext) -> {
+//					GL11.glTranslatef(0F, 0F, 0.5F);
+//					GL11.glRotatef(45F, 0f, 1f, 0f);
+//				    GL11.glScaled(0.55F, 0.55F, 0.55F);
+//				    GL11.glTranslatef(-0.4F, -0.8F, 0.9F);
+				}, 250, 1000)
+					)
+
+				.withFirstPersonPositioningZooming((renderContext) -> {
+				GL11.glTranslatef(-0.235F, -0.3F, -0.44F);
+				GL11.glRotatef(45F, 0f, 1f, 0f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+				// Zoom
+				GL11.glTranslatef(0.31F, -1.34f, 1.5f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+
+			/*	// ACOG Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), ModernWarfareMod.ACOG)) {
+					//System.out.println("Position me for Acog");
+					GL11.glTranslatef(0F, 0.3f, 1f);
+				} */
+
+				// Reflex Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Reflex)) {
+					//System.out.println("Position me for Reflex");
+					GL11.glTranslatef(0F, 0.5f, 0.7f);
+				} 
+
+				// Holo Zoom
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Holo2)) {
+					//System.out.println("Position me for Holo");
+					GL11.glTranslatef(1.38F, -1.115f, 3.2f);
+				} 
+
+				// Everything else
+				else {
+					GL11.glTranslatef(1.373F, -1.34f, 2.4f);
+				}
+
+
+				})
+			.withFirstPersonPositioningRunning((renderContext) -> {
+				GL11.glTranslatef(0.1F, -1.5F, -1F);
+				GL11.glRotatef(45F, 0f, 1f, 0f);
+				GL11.glRotatef(-50F, 1f, 0f, 0f);
+				GL11.glRotatef(0F, 0f, 0f, 1f);
+				GL11.glScaled(0.55F, 0.55F, 0.55F);
+				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
+			 })
+			 .withFirstPersonPositioningModifying((renderContext) -> {
+				 GL11.glScaled(1.2F, 1.2F, 1.2F);
+					GL11.glRotatef(-35F, 2f, 1f, 1f);
+					GL11.glTranslatef(-1F, 0.1F, 0F);
+			 })
+			  .withFirstPersonHandPositioning(
+					 (renderContext) -> {
+						 GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.6f, -0.1f, 0.4f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-40f, 1f, 0f, 0f);
+					 }, 
+					 (renderContext) -> {
+						 GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					 })
+
+			.withFirstPersonHandPositioningModifying(
+					 (renderContext) -> {
+						 GL11.glScalef(1.6f, 1.6f, 1.6f);
+						 GL11.glTranslatef(1.5f, 0.1f, -0.2f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-10f, 1f, 0f, 0f);
+					 }, 
+					 (renderContext) -> {
+						 GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.1f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					 })
+			.withFirstPersonLeftHandPositioningReloading(
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.9f, 0.8f, 0.5f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-100f, 20f, 20f, -20f);
+					}, 50, 200),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.5f, 0.5f, 0.3f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-30f, 1f, 0f, 0f);
+						 GL11.glRotatef(40f, 0f, 1f, 0f);
+					}, 50, 200),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.5f, 0.5f, 0.3f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-30f, 1f, 0f, 0f);
+						 GL11.glRotatef(40f, 0f, 1f, 0f);
+					}, 250, 0))
+
+			.withFirstPersonRightHandPositioningReloading(
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					}, 250, 1000),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					}, 250, 50),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					}, 250, 0))
+
+			.withFirstPersonLeftHandPositioningUnloading(
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.8f, 0.1f, 0.6f);
+						 GL11.glRotatef(60f, 0, 0f, 1f);
+						 GL11.glRotatef(-30f, 1f, 0f, 0f);
+						 GL11.glRotatef(40f, 0f, 1f, 0f);
+					}, 50, 200),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.8f, 0.1f, 0.6f);
+						 GL11.glRotatef(60f, 0, 0f, 1f);
+						 GL11.glRotatef(-30f, 1f, 0f, 0f);
+						 GL11.glRotatef(40f, 0f, 1f, 0f);
+					}, 50, 200)
+					)
+
+			.withFirstPersonRightHandPositioningUnloading(
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					}, 250, 1000),
+
+					new Transition((renderContext) -> { // Reload position
+						GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.13f, 0.38f, 0.52f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-95f, 1f, 0f, 0f);
+					}, 250, 50))
+
+			.withFirstPersonHandPositioningZooming(
+					(renderContext) -> {
+						 GL11.glScalef(3f, 3f, 3f);
+						 GL11.glTranslatef(0.4f, -0.1f, 0.5f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-60f, 1f, 0f, 0f);
+					 }, 
+					 (renderContext) -> {
+						 GL11.glScalef(3.3f, 3.3f, 3.3f);
+						 GL11.glTranslatef(-0.34f, 0.48f, 0.3f);
+						 GL11.glRotatef(90f, 0, 0f, 1f);
+						 GL11.glRotatef(-120f, 1f, 0f, 0f);
+						 GL11.glRotatef(10f, 0f, 0f, 1f);
+					 })
+			.build())
+		.withSpawnEntityDamage(5f)
+		.withSpawnEntityGravityVelocity(0.016f)
+
+
+		.build(MWC.modContext);
+	}
+}
+ 

--- a/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
+++ b/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
@@ -4,10 +4,8 @@ import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.models.*;
 import com.paneedah.mwc.proxies.CommonProxy;
 import com.paneedah.mwc.weapons.Attachments;
-import com.paneedah.mwc.weapons.AuxiliaryAttachments;
 import com.paneedah.mwc.weapons.Magazines;
 import com.paneedah.weaponlib.*;
-import com.paneedah.weaponlib.animation.Transform;
 import com.paneedah.weaponlib.animation.Transition;
 import com.paneedah.weaponlib.compatibility.RecoilParam;
 import com.paneedah.weaponlib.config.BalancePackManager.GunConfigurationGroup;
@@ -39,25 +37,8 @@ public class P220Factory implements GunFactory {
 		.withFlashOffsetY(() -> 0.1f)
 		.withConfigGroup(GunConfigurationGroup.RIFLES)
 		.withCreativeTab(MWC.WEAPONS_TAB)
-    	.withRecoilParam(new RecoilParam( // Recoil param
-                        // The weapon power
-                        15.0,
-                        // Muzzle climb divisor
-                        15.75,
-                        // "Stock Length"
-                        50.0,
-                        // Recovery rate from initial shot
-                        0.4,
-                        // Recovery rate @ "stock"
-                        0.3125,
-                        // Recoil rotation (Y)
-                        0.0,
-                        // Recoil rotation (Z)
-                        0.0,
-                        // Ads similarity divisor
-                        1.0
-                ))
-		.withCompatibleAttachment(Magazines.M9Mag30, (model) -> {
+
+		.withCompatibleAttachment(Magazines.M9A1Mag, (model) -> {
 			GL11.glTranslatef(0F, 0F, 0.1F);
 			})
 		.withCompatibleAttachment(Attachments.Laser, (p, s) -> {
@@ -69,7 +50,7 @@ public class P220Factory implements GunFactory {
 			GL11.glTranslatef(-0.25F, -1.2F, -4.6F);
 			GL11.glScaled(1.5F, 1.5F, 1.5F);
 		})
-		.withTextureNames("P225", "Electric")
+		.withTextureNames("p225")
 		.withRenderer(new WeaponRenderer.Builder()
 			.withModel(new P220())
 			.withEntityPositioning(itemStack -> {
@@ -91,9 +72,7 @@ public class P220Factory implements GunFactory {
 				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
 				})
 
-			//.withFirstPersonCustomRecoiled(CommonProxy.Glock21Mag, (p, itemStack) -> {})
-
-			.withFirstPersonCustomPositioning(Magazines.M9Mag30, (renderContext) -> {})
+			.withFirstPersonCustomPositioning(Magazines.M9A1Mag, (renderContext) -> {})
 
 			.withFirstPersonCustomPositioning(Attachments.P225Top.getRenderablePart(), (renderContext) -> {
 				if(renderContext.getWeaponInstance().getAmmo() == 0) {
@@ -155,7 +134,7 @@ public class P220Factory implements GunFactory {
 				}, 150, 50)
 			)
 
-			.withFirstPersonCustomPositioningUnloading(Magazines.M9Mag30,
+			.withFirstPersonCustomPositioningUnloading(Magazines.M9A1Mag,
 				new Transition((renderContext) -> {
 //					GL11.glTranslatef(0.2F, 0.5F, -0.2F);
 //					GL11.glRotatef(-20F, 1f, 0f, 0f);
@@ -170,7 +149,7 @@ public class P220Factory implements GunFactory {
 				}, 250, 1000)
 					)
 
-			.withFirstPersonCustomPositioningReloading(Magazines.M9Mag30,
+			.withFirstPersonCustomPositioningReloading(Magazines.M9A1Mag,
 				new Transition((renderContext) -> {
 					GL11.glTranslatef(0.05F, 1.3F, 0.4F);
 //					GL11.glRotatef(0F, 0f, 1f, 0f);
@@ -390,7 +369,6 @@ public class P220Factory implements GunFactory {
 			.build())
 		.withSpawnEntityDamage(5f)
 		.withSpawnEntityGravityVelocity(0.016f)
-
 
 		.build(MWC.modContext);
 	}

--- a/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
+++ b/src/main/java/com/paneedah/mwc/items/guns/P220Factory.java
@@ -1,11 +1,5 @@
 package com.paneedah.mwc.items.guns;
 
-import java.util.Arrays;
-
-import net.minecraft.item.Item;
-
-import org.lwjgl.opengl.GL11;
-
 import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.models.*;
 import com.paneedah.mwc.proxies.CommonProxy;
@@ -26,10 +20,7 @@ public class P220Factory implements GunFactory {
 
 	public Item createGun(CommonProxy commonProxy) {
 		return new Weapon.Builder()
-		.withModId(ModernWarfareMod.MODID)
 		.withName("P220")
-//		.withAmmo(CommonProxy.M9Mag)
-//		.withAmmoCapacity(10)
 		.withFireRate(0.6f)
 		.withRecoil(6f)
 		.withZoom(0.9f)
@@ -47,7 +38,8 @@ public class P220Factory implements GunFactory {
 		.withFlashOffsetX(() -> 0.2f)
 		.withFlashOffsetY(() -> 0.1f)
 		.withConfigGroup(GunConfigurationGroup.RIFLES)
-    .withRecoilParam(new RecoilParam( // Recoil param
+		.withCreativeTab(MWC.WEAPONS_TAB)
+    	.withRecoilParam(new RecoilParam( // Recoil param
                         // The weapon power
                         15.0,
                         // Muzzle climb divisor
@@ -65,12 +57,7 @@ public class P220Factory implements GunFactory {
                         // Ads similarity divisor
                         1.0
                 ))
-		.withCompatibleAttachment(AuxiliaryAttachments.P225Top, true, (model) -> {
-//			GL11.glTranslatef(0.1F, -0.5F, -1F);
-//			GL11.glRotatef(45F, 0f, 1f, 0f);
-//			GL11.glScaled(0.55F, 0.55F, 0.55F);
-		})
-		.withCompatibleAttachment(Magazines.M9BerettaMag, (model) -> {
+		.withCompatibleAttachment(Magazines.M9Mag30, (model) -> {
 			GL11.glTranslatef(0F, 0F, 0.1F);
 			})
 		.withCompatibleAttachment(Attachments.Laser, (p, s) -> {
@@ -89,11 +76,6 @@ public class P220Factory implements GunFactory {
 				GL11.glScaled(0.4F, 0.4F, 0.4F);
 				GL11.glRotatef(-90F, 0f, 0f, 4f);
 			})
-			.withInventoryPositioning(itemStack -> {
-				GL11.glScaled(0.35F, 0.35F, 0.35F);
-				GL11.glTranslatef(0, 0.8f, 0);
-				GL11.glRotatef(-120F, -0.5f, 7f, 3f);
-			})
 			.withThirdPersonPositioning((renderContext) -> {
 				GL11.glScaled(0.5F, 0.5F, 0.5F);
 				GL11.glTranslatef(-1.8F, -1F, 2F);
@@ -109,72 +91,11 @@ public class P220Factory implements GunFactory {
 				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
 				})
 
-			.withFirstPersonPositioningRecoiled((renderContext) -> {
-				GL11.glTranslatef(0F, -0.6F, -1.1F);
-				GL11.glRotatef(45F, 0f, 1f, 0f);
-				GL11.glRotatef(-10F, 1f, 0f, 0f);
-				GL11.glScaled(0.55F, 0.55F, 0.55F);
-				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
-				})
-
-			.withFirstPersonPositioningCustomRecoiled(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
-				GL11.glTranslatef(0F, 0F, 0.5F);
-//				GL11.glRotatef(45F, 0f, 1f, 0f);
-//				GL11.glScaled(0.55F, 0.55F, 0.55F);
-				})
-
-
-			.withFirstPersonPositioningCustomZoomingRecoiled(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
-				GL11.glTranslatef(0F, 0F, 0.5F);
-//				GL11.glRotatef(45F, 0f, 1f, 0f);
-//				GL11.glScaled(0.55F, 0.55F, 0.55F);
-				})
-
-			.withFirstPersonPositioningCustomRecoiled(Magazines.M9BerettaMag, (renderContext) -> {})
-
-			.withFirstPersonPositioningCustomZoomingRecoiled(Magazines.M9BerettaMag, (renderContext) -> {})
-
-			.withFirstPersonPositioningZoomingRecoiled((renderContext) -> {
-				GL11.glTranslatef(-0.3F, -0.4F, -0.5F);
-				GL11.glRotatef(45F, 0f, 1f, 0f);
-				GL11.glRotatef(-4F, 1f, 0f, 0f);
-				GL11.glScaled(0.55F, 0.55F, 0.55F);
-
-				// Zoom
-				GL11.glTranslatef(0.31F, -1.34f, 1.5f);
-				GL11.glScaled(0.55F, 0.55F, 0.55F);
-
-			/*	// ACOG Zoom
-				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), ModernWarfareMod.ACOG)) {
-					//System.out.println("Position me for Acog");
-					GL11.glTranslatef(0F, 0.3f, 1f);
-				} */
-
-				// Reflex Zoom
-				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Reflex)) {
-					//System.out.println("Position me for Reflex");
-					GL11.glTranslatef(0F, 0.5f, 0.7f);
-				} 
-
-				// Holo Zoom
-				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Holo2)) {
-					//System.out.println("Position me for Holo");
-					GL11.glTranslatef(1.38F, -1.115f, 3.2f);
-				} 
-
-				// Everything else
-				else {
-					GL11.glTranslatef(1.373F, -1.34f, 2.4f);
-				}
-
-
-				})
-
 			//.withFirstPersonCustomRecoiled(CommonProxy.Glock21Mag, (p, itemStack) -> {})
 
-			.withFirstPersonCustomPositioning(Magazines.M9BerettaMag, (renderContext) -> {})
+			.withFirstPersonCustomPositioning(Magazines.M9Mag30, (renderContext) -> {})
 
-			.withFirstPersonCustomPositioning(AuxiliaryAttachments.P225Top.getRenderablePart(), (renderContext) -> {
+			.withFirstPersonCustomPositioning(Attachments.P225Top.getRenderablePart(), (renderContext) -> {
 				if(renderContext.getWeaponInstance().getAmmo() == 0) {
 					GL11.glTranslatef(0F, 0F, 0.5F);
 				}
@@ -234,7 +155,7 @@ public class P220Factory implements GunFactory {
 				}, 150, 50)
 			)
 
-			.withFirstPersonCustomPositioningUnloading(Magazines.M9BerettaMag,
+			.withFirstPersonCustomPositioningUnloading(Magazines.M9Mag30,
 				new Transition((renderContext) -> {
 //					GL11.glTranslatef(0.2F, 0.5F, -0.2F);
 //					GL11.glRotatef(-20F, 1f, 0f, 0f);
@@ -249,7 +170,7 @@ public class P220Factory implements GunFactory {
 				}, 250, 1000)
 					)
 
-			.withFirstPersonCustomPositioningReloading(Magazines.M9BerettaMag,
+			.withFirstPersonCustomPositioningReloading(Magazines.M9Mag30,
 				new Transition((renderContext) -> {
 					GL11.glTranslatef(0.05F, 1.3F, 0.4F);
 //					GL11.glRotatef(0F, 0f, 1f, 0f);
@@ -271,7 +192,7 @@ public class P220Factory implements GunFactory {
 					)
 
 
-			.withFirstPersonCustomPositioningUnloading(AuxiliaryAttachments.P225Top.getRenderablePart(),
+			.withFirstPersonCustomPositioningUnloading(Attachments.P225Top.getRenderablePart(),
 				new Transition((renderContext) -> {
 					GL11.glTranslatef(0F, 0F, 0.5F);
 //					GL11.glRotatef(0F, 0f, 1f, 0f);
@@ -286,7 +207,7 @@ public class P220Factory implements GunFactory {
 				}, 250, 1000)
 					)
 
-			.withFirstPersonCustomPositioningReloading(AuxiliaryAttachments.P225Top.getRenderablePart(),
+			.withFirstPersonCustomPositioningReloading(Attachments.P225Top.getRenderablePart(),
 				new Transition((renderContext) -> {
 					GL11.glTranslatef(0F, 0F, 0.5F);
 //					GL11.glRotatef(0F, 0f, 1f, 0f);
@@ -329,7 +250,7 @@ public class P220Factory implements GunFactory {
 				} 
 
 				// Holo Zoom
-				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Holo2)) {
+				if(Weapon.isActiveAttachment(renderContext.getWeaponInstance(), Attachments.Holographic)) {
 					//System.out.println("Position me for Holo");
 					GL11.glTranslatef(1.38F, -1.115f, 3.2f);
 				} 
@@ -341,14 +262,6 @@ public class P220Factory implements GunFactory {
 
 
 				})
-			.withFirstPersonPositioningRunning((renderContext) -> {
-				GL11.glTranslatef(0.1F, -1.5F, -1F);
-				GL11.glRotatef(45F, 0f, 1f, 0f);
-				GL11.glRotatef(-50F, 1f, 0f, 0f);
-				GL11.glRotatef(0F, 0f, 0f, 1f);
-				GL11.glScaled(0.55F, 0.55F, 0.55F);
-				GL11.glTranslatef(-1.1F, -0.76F, 1.5F);
-			 })
 			 .withFirstPersonPositioningModifying((renderContext) -> {
 				 GL11.glScaled(1.2F, 1.2F, 1.2F);
 					GL11.glRotatef(-35F, 2f, 1f, 1f);

--- a/src/main/java/com/paneedah/mwc/weapons/Attachments.java
+++ b/src/main/java/com/paneedah/mwc/weapons/Attachments.java
@@ -529,6 +529,7 @@ public class Attachments {
     public static ItemAttachment<Weapon> RPKBarrel;
     public static ItemAttachment<Weapon> AKIron;
     public static ItemAttachment<Weapon> AK12Iron;
+    public static ItemAttachment<Weapon> P225Top;
     public static ItemAttachment<Weapon> Remington870Pump;
     public static ItemAttachment<Weapon> Remington870PoliceMagnumPump;
     public static ItemAttachment<Weapon> Remington870MagpulPump;
@@ -17487,6 +17488,46 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("USPMatchCompensator").withTextureName("Dummy.png")
+                .build(MWC.modContext);
+
+        P225Top = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
+                .withRenderablePart()
+                .withCreativeTab(MWC.ATTACHMENTS_TAB)
+                .withModel(new com.paneedah.mwc.models.USPMatchCompensator(), "gun.png")
+                .withApply((a, i) -> {
+                    i.setRecoil(i.getWeapon().getRecoil() * 0.4f);
+                }).withFirstPersonModelPositioning(model -> {
+                    if (model instanceof com.paneedah.mwc.models.P225Top) {
+                        GL11.glTranslatef(0.7F, -1.1F, 0.5F);
+                        GL11.glRotatef(30F, 0f, 1f, 0f);
+                        GL11.glScaled(0.5F, 0.5F, 0.5F);
+                    }
+
+                }).withThirdPersonModelPositioning(model -> {
+                    if (model instanceof com.paneedah.mwc.models.P225Top) {
+                        GL11.glTranslatef(-0.7F, -0.5F, 0.6F);
+                        GL11.glRotatef(-50F, 0f, 1f, 0f);
+                        GL11.glRotatef(80F, 1f, 0f, 0f);
+                        GL11.glScaled(0.5F, 0.5F, 0.5F);
+                    }
+                }).withInventoryModelPositioning(model -> {
+                    if (model instanceof com.paneedah.mwc.models.P225Top) {
+                        GL11.glTranslatef(0.6F, 0.6F, -3.7F);
+                        // GL11.glRotatef(10F, 1f, 0f, 0f);
+                        GL11.glRotatef(-180F, 0f, 1f, 0f);
+                        GL11.glRotatef(0F, 0f, 0f, 1f);
+                        GL11.glScaled(1.3F, 1.3F, 1.3f);
+
+                    }
+                }).withEntityModelPositioning(model -> {
+                    if (model instanceof com.paneedah.mwc.models.P225Top) {
+                        GL11.glTranslatef(0.1F, 0.2F, 0.4F);
+                        GL11.glRotatef(90F, 0f, 0f, 1f);
+                        GL11.glScaled(0.6F, 0.6F, 0.6F);
+                    }
+                })
+                .withRenderablePart()
+                .withName("P225Top").withTextureName("Dummy.png")
                 .build(MWC.modContext);
 
     }


### PR DESCRIPTION
## 📝 Description

The P220 was removed in [this](https://github.com/vic4games/modern-warfare/commit/bf1d576eea29f93c160616a815f33feb212c2481#diff-c5fcadc14d208e645fd21cfae50b48a29a1175277d86f2028dc0c877b1e3b725) commit in VMW, but its model remains it the MWC code ([here](https://github.com/strubium/Modern-Warfare-Cubed/blob/p220-backport/src/main/java/com/paneedah/mwc/models/P220.java)).  

## 🎯 Goals

- Port P220Factory from Vic's github 
- Make it as "functional" as a non-revamped gun 

## ❌ Non Goals

- Revamp P220

## 🚦 Testing 

Soon brother

## ⏮️ Backwards Compatibility 

1.12.2

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed

## 😄 [optional] What gif best describes this PR or how it makes you feel?
