### PR TITLE
Fixed dedicated server crashing

### DIFF
--- a/src/main/java/com/paneedah/mwc/items/equipment/carryable/ItemBackpack.java
+++ b/src/main/java/com/paneedah/mwc/items/equipment/carryable/ItemBackpack.java
@@ -38,7 +38,8 @@ public class ItemBackpack extends ItemCarryable {
 
             MWC.modContext.registerRenderableItem(name, itemBackpack, FMLCommonHandler.instance().getSide() == Side.CLIENT ? new StaticModelSourceRenderer(transforms) : null);
 
-            COOKING_QUEUE.add(itemBackpack);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(itemBackpack);
 
             return itemBackpack;
         }

--- a/src/main/java/com/paneedah/mwc/items/equipment/carryable/ItemBelt.java
+++ b/src/main/java/com/paneedah/mwc/items/equipment/carryable/ItemBelt.java
@@ -42,7 +42,8 @@ public class ItemBelt extends ItemCarryable {
 
             MWC.modContext.registerRenderableItem(name, itemBelt, FMLCommonHandler.instance().getSide() == Side.CLIENT ? new StaticModelSourceRenderer(transforms) : null);
 
-            COOKING_QUEUE.add(itemBelt);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(itemBelt);
 
             return itemBelt;
         }

--- a/src/main/java/com/paneedah/weaponlib/AttachmentBuilder.java
+++ b/src/main/java/com/paneedah/weaponlib/AttachmentBuilder.java
@@ -323,7 +323,8 @@ public class AttachmentBuilder<T> {
             //System.err.println("!!!No recipe defined for attachment " + name);
         }
 
-        COOKING_QUEUE.add(attachment);
+        if (modContext.isClient())
+            COOKING_QUEUE.add(attachment);
 
         return attachment;
     }
@@ -340,7 +341,8 @@ public class AttachmentBuilder<T> {
     public <V extends ItemAttachment<T>> V build(ModContext modContext, Class<V> target) {
         final V attachment = target.cast(build(modContext));
 
-        COOKING_QUEUE.add(attachment);
+        if (modContext.isClient())
+            COOKING_QUEUE.add(attachment);
 
         return attachment;
     }

--- a/src/main/java/com/paneedah/weaponlib/CustomArmor.java
+++ b/src/main/java/com/paneedah/weaponlib/CustomArmor.java
@@ -24,6 +24,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -332,7 +333,8 @@ public class CustomArmor extends ItemArmor implements ExposureProtection , ISpec
             if (creativeTab != null)
                 armorHelmet.setCreativeTab(creativeTab);
 
-            COOKING_QUEUE.add(armorHelmet);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(armorHelmet);
 
             return armorHelmet;
         }
@@ -368,7 +370,8 @@ public class CustomArmor extends ItemArmor implements ExposureProtection , ISpec
             armorChest.shieldIndicatorMaskTextureName = shieldIndicatorMaskTextureName;
             armorChest.shieldIndicatorProgressBarTextureName = shieldIndicatorProgressBarTextureName;
 
-            COOKING_QUEUE.add(armorChest);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(armorChest);
 
             return armorChest;
         }
@@ -394,7 +397,8 @@ public class CustomArmor extends ItemArmor implements ExposureProtection , ISpec
 //            armorBoots.shieldRegenerationRate = shieldRegenerationRate;
 //            armorBoots.shieldRegenerationTimeout = shieldRegenerationTimeout;
 
-            COOKING_QUEUE.add(armorBoots);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(armorBoots);
 
             return armorBoots;
         }

--- a/src/main/java/com/paneedah/weaponlib/ItemVest.java
+++ b/src/main/java/com/paneedah/weaponlib/ItemVest.java
@@ -234,7 +234,8 @@ public class ItemVest extends Item implements ISpecialArmor, ModelSource, IModer
 
             modContext.registerRenderableItem(name, item, FMLCommonHandler.instance().getSide() == Side.CLIENT ? new StaticModelSourceRenderer(transforms) : null);
 
-            COOKING_QUEUE.add(item);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(item);
 
             return item;
         }

--- a/src/main/java/com/paneedah/weaponlib/Weapon.java
+++ b/src/main/java/com/paneedah/weaponlib/Weapon.java
@@ -1053,7 +1053,8 @@ public class Weapon extends Item implements PlayerItemInstanceFactory<PlayerWeap
             // have a crafting recipe.
             CraftingRegistry.registerHook(weapon);
 
-            COOKING_QUEUE.add(weapon);
+            if (FMLCommonHandler.instance().getSide().isClient())
+                COOKING_QUEUE.add(weapon);
 
             return weapon;
         }


### PR DESCRIPTION
## 📝 Description
This is basically my previous pull request but done right.

## 🎯 Goals
Make dedicated servers not crash during `preinit` by not calling client-only methods that caused the crash on dedicated servers.

## ❌ Non Goals
Make it a dirty hack

## 🚦 Testing 
Start a server. If it crashes then something's still wrong

## ⏮️ Backwards Compatibility 
Everything should be fine

## 📚 Related Issues & Documents
Removed @SideOnly() from ClientEventHandler.java to prevent crashing … #414 

## 🖼️ Screenshots/Recordings

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [X] 🙅 No documentation needed

## 😄 [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced client-side processing for various items including backpacks, belts, attachments, armor, vests, and weapons by introducing conditional checks. This ensures that certain actions are only executed on the client side, improving game performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->