### PR TITLE
Fix broken GS Integration

### DIFF
--- a/src/main/java/com/paneedah/mwc/groovyscript/MWCGroovyPlugin.java
+++ b/src/main/java/com/paneedah/mwc/groovyscript/MWCGroovyPlugin.java
@@ -23,6 +23,6 @@ public class MWCGroovyPlugin implements GroovyPlugin {
 
     @Override
     public void onCompatLoaded(GroovyContainer<?> groovyContainer) {
-        groovyContainer.getVirtualizedRegistrar().addFieldsOf(this);
+        groovyContainer.getRegistrar().addFieldsOf(this);
     }
 }

--- a/src/main/java/com/paneedah/mwc/groovyscript/MWCGroovyPlugin.java
+++ b/src/main/java/com/paneedah/mwc/groovyscript/MWCGroovyPlugin.java
@@ -23,6 +23,6 @@ public class MWCGroovyPlugin implements GroovyPlugin {
 
     @Override
     public void onCompatLoaded(GroovyContainer<?> groovyContainer) {
-        groovyContainer.getRegistrar().addFieldsOf(this);
+        groovyContainer.getRegistrar().addRegistry(craftingStation);
     }
 }

--- a/src/main/java/com/paneedah/mwc/groovyscript/script/CraftingStation.java
+++ b/src/main/java/com/paneedah/mwc/groovyscript/script/CraftingStation.java
@@ -2,8 +2,6 @@ package com.paneedah.mwc.groovyscript.script;
 
 import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.api.IIngredient;
-import com.cleanroommc.groovyscript.helper.ingredient.ItemsIngredient;
-import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import com.paneedah.mwc.groovyscript.recipes.GSCrafting;


### PR DESCRIPTION
<!--
  🚀 For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  📚 Before submitting a Pull Request, make sure you agree to the following rules:
  1. 🛠️ Only one subject at a time, we will accept "Add balloon", we won't accept "Add balloon & Piñata & Fireworks"
  2. 📝 Use descriptive commit messages, we can't really know what "fix" or "what the hell" or "aaaaaaa" changed.
  3. 📖 Update any related documentation and include any relevant screenshots.
  4. ⛓️ Do not make a pull request to another pull request branch. 
        You can depend on other pull requests, but you will need to wait for them to be merged before submitting your pull request.
  5. Complete the pull request template. 
        It is fine for draft pull requests to not have the template completed.

  🚫 Please note, pull requests not adhering to these rules may be rejected
-->

## 📝 Description

<!-- 
Please do not leave this blank
Example:
    This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR Fixes currently broken GS container registry along deprecated calls.

## 🎯 Goals

<!--
What do you aim to achieve with this?
Example:
    - Make X faster to render
    - Reduce the edge cases of Y
    - Make Z easier to work with
-->

Fix broken GS container registry
Replace deprecated calls with futureproof one

## ❌ Non Goals

<!--
Precise what are you not aiming to achieve with this?
Example:
    - It is not a goal to fix issues with X
    - It is not a goal to make Y faster
    - It is not a goal to add Z features
-->

It is not a goal to overhaul GS integration

## 🚦 Testing 

<!--
What steps did you take to test and verify your changes do not have issues? 
Provide instructions so we can reproduce.
-->

Used this script to verify recipe customization working again

```groovy
mods.mwc.craftingstation

mods.mwc.craftingstation.recipeBuilder()
  .output(item('minecraft:nether star'))
  .setYield(0.5)
  .input(item('minecraft:iron_ingot') * 4)
  .setYield(1)
  .input(item('minecraft:coal'))
  .register()
```

## ⏮️ Backwards Compatibility 

<!--
Is this change backwards compatible?
If not, what might the impact be?
-->

should be backward compatible

## 📚 Related Issues & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
N/A

## 🖼️ Screenshots/Recordings

<!-- Visual changes require screenshots -->
![image](https://github.com/Cubed-Development/Modern-Warfare-Cubed/assets/49832212/e887243b-e22d-4ace-b890-cf1877988db0)

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed

## 😄 [optional] What gif best describes this PR or how it makes you feel?
