### PR TITLE
Use new RedCore import

### DIFF
--- a/src/main/java/com/paneedah/mwc/network/handlers/BalancePackClientMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/BalancePackClientMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.BalancePackClientMessage;
 import com.paneedah.weaponlib.config.BalancePackManager;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/paneedah/mwc/network/handlers/BlockHitMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/BlockHitMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.network.messages.BlockHitMessage;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import io.redstudioragnarok.redcore.vectors.Vector3F;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/BloodClientMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/BloodClientMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.BloodClientMessage;
 import com.paneedah.weaponlib.jim.util.RandomUtil;
 import com.paneedah.weaponlib.particle.ParticleBlood;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import io.redstudioragnarok.redcore.vectors.Vector3F;
 import net.jafama.FastMath;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/CraftingClientMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/CraftingClientMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.CraftingClientMessage;
 import com.paneedah.mwc.network.messages.CraftingServerMessage;
 import com.paneedah.weaponlib.crafting.CraftingFileManager;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/paneedah/mwc/network/handlers/CraftingServerMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/CraftingServerMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.CraftingClientMessage;
 import com.paneedah.mwc.network.messages.CraftingServerMessage;
 import com.paneedah.weaponlib.crafting.CraftingFileManager;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/EntityInventorySyncMessageClientHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/EntityInventorySyncMessageClientHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.capabilities.EquipmentCapability;
 import com.paneedah.mwc.equipment.inventory.EquipmentInventory;
 import com.paneedah.mwc.network.messages.EntityInventorySyncMessage;
 import com.paneedah.weaponlib.ModContext;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.Entity;

--- a/src/main/java/com/paneedah/mwc/network/handlers/EntityInventorySyncMessageServerHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/EntityInventorySyncMessageServerHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.capabilities.EquipmentCapability;
 import com.paneedah.mwc.equipment.inventory.EquipmentInventory;
 import com.paneedah.mwc.network.messages.EntityInventorySyncMessage;
 import com.paneedah.weaponlib.ModContext;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/com/paneedah/mwc/network/handlers/EntityPickupMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/EntityPickupMessageHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.network.messages.EntityPickupMessage;
 import com.paneedah.weaponlib.HighIQSpawnEgg;
 import com.paneedah.weaponlib.SecondaryEntityRegistry;
 import com.paneedah.weaponlib.ai.EntityCustomMob;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/paneedah/mwc/network/handlers/ExplosionMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/ExplosionMessageHandler.java
@@ -1,7 +1,7 @@
 package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.ExplosionMessage;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import io.redstudioragnarok.redcore.vectors.Vector3D;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/com/paneedah/mwc/network/handlers/ExposureMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/ExposureMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.ExposureMessage;
 import com.paneedah.weaponlib.compatibility.CompatibleExposureCapability;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/paneedah/mwc/network/handlers/GrenadeMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/GrenadeMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.GrenadeMessage;
 import com.paneedah.weaponlib.grenade.GrenadeAttackAspect;
 import com.paneedah.weaponlib.grenade.ItemGrenade;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/com/paneedah/mwc/network/handlers/LivingEntityTrackerMessageMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/LivingEntityTrackerMessageMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.LivingEntityTrackerMessage;
 import com.paneedah.weaponlib.compatibility.CompatiblePlayerEntityTrackerProvider;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.NoArgsConstructor;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/MeleeAttackMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/MeleeAttackMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.MeleeAttackMessage;
 import com.paneedah.weaponlib.melee.ItemMelee;
 import com.paneedah.weaponlib.melee.MeleeAttackAspect;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/com/paneedah/mwc/network/handlers/MuzzleFlashMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/MuzzleFlashMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.MuzzleFlashMessage;
 import com.paneedah.weaponlib.ClientEventHandler;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/paneedah/mwc/network/handlers/NightVisionToggleMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/NightVisionToggleMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.NightVisionToggleMessage;
 import com.paneedah.weaponlib.CustomArmor;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;

--- a/src/main/java/com/paneedah/mwc/network/handlers/OpenCustomPlayerInventoryGuiMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/OpenCustomPlayerInventoryGuiMessageHandler.java
@@ -1,7 +1,7 @@
 package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.OpenCustomPlayerInventoryGuiMessage;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/com/paneedah/mwc/network/handlers/OpenDoorMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/OpenDoorMessageHandler.java
@@ -1,7 +1,7 @@
 package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.OpenDoorMessage;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;

--- a/src/main/java/com/paneedah/mwc/network/handlers/PermitMessageClientHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/PermitMessageClientHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.network.messages.PermitMessage;
 import com.paneedah.weaponlib.CommonModContext;
 import com.paneedah.weaponlib.PlayerItemInstance;
 import com.paneedah.weaponlib.state.Permit;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/PermitMessageServerHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/PermitMessageServerHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.network.messages.PermitMessage;
 import com.paneedah.weaponlib.CommonModContext;
 import com.paneedah.weaponlib.PlayerItemInstance;
 import com.paneedah.weaponlib.state.Permit;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/ShellMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/ShellMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.ShellMessageClient;
 import com.paneedah.weaponlib.ClientEventHandler;
 import com.paneedah.weaponlib.render.shells.ShellParticleSimulator.Shell;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/paneedah/mwc/network/handlers/SpawnParticleMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/SpawnParticleMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.SpawnParticleMessage;
 import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.particle.ExplosionSmokeFX;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import io.redstudioragnarok.redcore.vectors.Vector3F;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/paneedah/mwc/network/handlers/SpreadableExposureMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/SpreadableExposureMessageHandler.java
@@ -3,7 +3,7 @@ package com.paneedah.mwc.network.handlers;
 import com.paneedah.mwc.network.messages.SpreadableExposureMessage;
 import com.paneedah.weaponlib.SpreadableExposure;
 import com.paneedah.weaponlib.compatibility.CompatibleExposureCapability;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/paneedah/mwc/network/handlers/TryFireMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/TryFireMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.TryFireMessage;
 import com.paneedah.weaponlib.WeaponFireAspect;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;

--- a/src/main/java/com/paneedah/mwc/network/handlers/VehicleClientMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/VehicleClientMessageHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.network.messages.VehicleClientMessage;
 import com.paneedah.weaponlib.vehicle.EntityVehicle;
 import com.paneedah.weaponlib.vehicle.network.VehicleDataContainer;
 import com.paneedah.weaponlib.vehicle.network.VehiclePacketLatencyTracker;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/paneedah/mwc/network/handlers/VehicleControlMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/VehicleControlMessageHandler.java
@@ -4,7 +4,7 @@ import com.paneedah.mwc.network.messages.VehicleClientMessage;
 import com.paneedah.mwc.network.messages.VehicleControlMessage;
 import com.paneedah.weaponlib.vehicle.EntityVehicle;
 import com.paneedah.weaponlib.vehicle.network.VehicleDataContainer;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;

--- a/src/main/java/com/paneedah/mwc/network/handlers/VehicleInteractMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/VehicleInteractMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.VehicleInteractMessage;
 import com.paneedah.weaponlib.vehicle.EntityVehicle;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/paneedah/mwc/network/handlers/WorkbenchClientMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/WorkbenchClientMessageHandler.java
@@ -2,7 +2,7 @@ package com.paneedah.mwc.network.handlers;
 
 import com.paneedah.mwc.network.messages.WorkbenchClientMessage;
 import com.paneedah.weaponlib.crafting.base.TileEntityStation;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/paneedah/mwc/network/handlers/WorkbenchServerMessageHandler.java
+++ b/src/main/java/com/paneedah/mwc/network/handlers/WorkbenchServerMessageHandler.java
@@ -9,7 +9,7 @@ import com.paneedah.weaponlib.crafting.ammopress.TileEntityAmmoPress;
 import com.paneedah.weaponlib.crafting.base.TileEntityStation;
 import com.paneedah.weaponlib.crafting.workbench.TileEntityWorkbench;
 import io.redstudioragnarok.redcore.utils.MathUtil;
-import io.redstudioragnarok.redcore.utils.NetworkUtil;
+import dev.redstudio.redcore.utils.NetworkUtil;
 import lombok.NoArgsConstructor;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;


### PR DESCRIPTION
## 📝 Description

Replaces import io.redstudioragnarok.redcore.utils.NetworkUtil; with import dev.redstudio.redcore.utils.NetworkUtil;


## 🎯 Goals

* Replace the deprecated import with the new one that is better

## ❌ Non Goals

- Break the mod

## 🚦 Testing 

Yes

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed