### PR TITLE
Improve Registration + Slight NPC cleanup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -95,6 +95,7 @@ like knowing which weapon is better or whether an attachment will be useful to y
 - Adjusted configuration categories for all weapons
   - SMG -> SUBMACHINE_GUN, RIFLES -> RIFLE, SIDEARM / REVOLVER -> HANDGUN 
 - Improved and cleaned up Blood particles (Now supports arbitrary sizes like 64x64)
+- Soldiers now are neutral to the player until they are attacked  
 
 ### Fixed
 

--- a/src/main/java/com/paneedah/mwc/CustomSpawnEggs.java
+++ b/src/main/java/com/paneedah/mwc/CustomSpawnEggs.java
@@ -7,12 +7,12 @@ import static com.paneedah.mwc.ProjectConstants.ID;
 
 public class CustomSpawnEggs {
 
-    public static HighIQSpawnEgg TURRET_EGG;
-    public static HighIQSpawnEgg TURRETUPGRADED_EGG;
-    public static HighIQSpawnEgg TURRETSILENCED_EGG;
+    public static HighIQSpawnEgg turretEgg;
+    public static HighIQSpawnEgg turretEggUpgraded;
+    public static HighIQSpawnEgg turretEggSilenced;
 
     public static void init(CommonProxy proxy) {
-        TURRET_EGG = new HighIQSpawnEgg.Builder()
+        turretEgg = new HighIQSpawnEgg.Builder()
                 .withID(1)
                 .withItemName("turret")
                 .withEntitySpawnName("turret")
@@ -20,7 +20,7 @@ public class CustomSpawnEggs {
                 .withCreativeTab(MWC.WEAPONS_TAB)
                 .build();
 
-        TURRETUPGRADED_EGG = new HighIQSpawnEgg.Builder()
+        turretEggUpgraded = new HighIQSpawnEgg.Builder()
                 .withID(2)
                 .withItemName("turretupgraded")
                 .withEntitySpawnName("turretupgraded")
@@ -28,7 +28,7 @@ public class CustomSpawnEggs {
                 .withCreativeTab(MWC.WEAPONS_TAB)
                 .build();
 
-        TURRETSILENCED_EGG = new HighIQSpawnEgg.Builder()
+        turretEggSilenced = new HighIQSpawnEgg.Builder()
                 .withID(3)
                 .withItemName("turretsilenced")
                 .withEntitySpawnName("turretsilenced")

--- a/src/main/java/com/paneedah/mwc/CustomSpawnEggs.java
+++ b/src/main/java/com/paneedah/mwc/CustomSpawnEggs.java
@@ -11,7 +11,7 @@ public class CustomSpawnEggs {
     public static HighIQSpawnEgg TURRETUPGRADED_EGG;
     public static HighIQSpawnEgg TURRETSILENCED_EGG;
 
-    public static void init(Object mod, CommonProxy proxy) {
+    public static void init(CommonProxy proxy) {
         TURRET_EGG = new HighIQSpawnEgg.Builder()
                 .withID(1)
                 .withItemName("turret")

--- a/src/main/java/com/paneedah/mwc/Grenades.java
+++ b/src/main/java/com/paneedah/mwc/Grenades.java
@@ -18,7 +18,7 @@ public class Grenades {
     public static ItemAttachment<ItemGrenade> GrenadeSafetyPin;
 
 
-    public static void init(Object mod, CommonProxy commonProxy) {
+    public static void init(CommonProxy commonProxy) {
         GrenadeSafetyPin = new AttachmentBuilder<ItemGrenade>().withCategory(AttachmentCategory.EXTRA).withModel(new com.paneedah.mwc.models.Pin(), "gun.png").withName("GrenadeSafetyPin").withRenderablePart().withTextureName("Dummy.png").build(MWC.modContext);
 
         FuseGrenade = new FuseGrenadeFactory().createGrenade(commonProxy);

--- a/src/main/java/com/paneedah/mwc/entities/Entities.java
+++ b/src/main/java/com/paneedah/mwc/entities/Entities.java
@@ -1,9 +1,8 @@
 package com.paneedah.mwc.entities;
 
-import com.paneedah.mwc.MWC;
-import com.paneedah.mwc.proxies.CommonProxy;
 import com.paneedah.mwc.weapons.Guns;
 import com.paneedah.mwc.weapons.Magazines;
+import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.ai.BetterAINearestAttackableTarget;
 import com.paneedah.weaponlib.ai.EntityAIAttackRangedWeapon;
 import com.paneedah.weaponlib.ai.EntityConfiguration;
@@ -20,7 +19,7 @@ import net.minecraftforge.common.BiomeDictionary;
 
 public class Entities {
 
-    public static void init(CommonProxy commonProxy) {
+    public static void init(ModContext modContext) {
 
         new EntityConfiguration.Builder()
                 .withName("terrorist")
@@ -75,7 +74,7 @@ public class Entities {
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityWitch.class, true))
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityZombieVillager.class, true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "tyke", true))
-                .register(MWC.modContext);
+                .register(modContext);
 
         new EntityConfiguration.Builder()
                 .withName("soldier")
@@ -103,7 +102,6 @@ public class Entities {
                 .withAiTask(7, e -> new EntityAIBreakDoor(e))
 
                 .withAiTargetTask(1, e -> new EntityAIHurtByTarget((EntityCreature) e, false))
-                .withAiTargetTask(2, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityPlayer.class, true))
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityVillager.class, true))
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityZombie.class, true))
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityHusk.class, true))
@@ -126,7 +124,7 @@ public class Entities {
                 .withAiTargetTask(3, e -> new EntityAINearestAttackableTarget<>((EntityCreature) e, EntityZombieVillager.class, true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "terrorist", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "tyke", true))
-                .register(MWC.modContext);
+                .register(modContext);
 
         new EntityConfiguration.Builder()
                 .withName("turret")
@@ -176,7 +174,8 @@ public class Entities {
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "soldier", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "terrorist", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "tyke", true))
-                .register(MWC.modContext);
+                .register(modContext);
+
         new EntityConfiguration.Builder()
                 .withName("turretupgraded")
                 .withBaseClass(EntityCustomMob.class)
@@ -225,7 +224,7 @@ public class Entities {
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "soldier", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "terrorist", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "tyke", true))
-                .register(MWC.modContext);
+                .register(modContext);
 
         new EntityConfiguration.Builder()
                 .withName("turretsilenced")
@@ -275,6 +274,6 @@ public class Entities {
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "soldier", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "terrorist", true))
                 .withAiTargetTask(4, e -> new BetterAINearestAttackableTarget<>((EntityCreature) e, EntityCustomMob.class, "tyke", true))
-                .register(MWC.modContext);
+                .register(modContext);
     }
 }

--- a/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
+++ b/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
@@ -62,22 +62,22 @@ public class CommonProxy {
         DataSerializers.registerSerializer(VehiclePhysSerializer.SERIALIZER);
 
         // Special object initialization
-        SpecialAttachments.init(mod, MWC.modContext);
+        SpecialAttachments.init(MWC.modContext);
 
         Backpacks.createEquipment(MWC.modContext);
         Belts.createEquipment(MWC.modContext);
         Vests.createEquipment(MWC.modContext);
         Armors.createEquipment(MWC.modContext);
 
-        Attachments.init(mod);
-        AuxiliaryAttachments.init(mod);
-        GunSkins.init(mod);
-        Bullets.init(mod);
-        Magazines.init(mod);
-        Guns.init(mod, this);
+        Attachments.init(MWC.modContext);
+        AuxiliaryAttachments.init(MWC.modContext);
+        GunSkins.init(MWC.modContext);
+        Bullets.init(MWC.modContext);
+        Magazines.init(MWC.modContext);
+        Guns.init(this);
         Electronics.createEquipment(MWC.modContext);
-        Grenades.init(mod, this);
-        CustomSpawnEggs.init(mod, this);
+        Grenades.init(this);
+        CustomSpawnEggs.init(this);
 
         TurretBaseFactory.createTileEntity(MWC.modContext);
         TileEntities.createTileEntity(MWC.modContext);
@@ -93,8 +93,8 @@ public class CommonProxy {
     public void init(final MWC mod) {
         MWC.modContext.init(mod);
 
-        Entities.init(this);
-        Vehicles.init(this);
+        Entities.init(MWC.modContext);
+        Vehicles.init(MWC.modContext);
 
         GameRegistry.registerWorldGenerator(new ModernWorldGenerator(), 0);
     }

--- a/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
+++ b/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
@@ -18,7 +18,6 @@ import com.paneedah.weaponlib.animation.SpecialAttachments;
 import com.paneedah.weaponlib.vehicle.network.VehicleDataSerializer;
 import com.paneedah.weaponlib.vehicle.network.VehiclePhysSerializer;
 import net.minecraft.network.datasync.DataSerializers;
-import net.minecraftforge.fml.common.ProgressManager;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 

--- a/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
+++ b/src/main/java/com/paneedah/mwc/proxies/CommonProxy.java
@@ -18,41 +18,14 @@ import com.paneedah.weaponlib.animation.SpecialAttachments;
 import com.paneedah.weaponlib.vehicle.network.VehicleDataSerializer;
 import com.paneedah.weaponlib.vehicle.network.VehiclePhysSerializer;
 import net.minecraft.network.datasync.DataSerializers;
+import net.minecraftforge.fml.common.ProgressManager;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public class CommonProxy {
 
-    /*
-    public static Item ElectronicCircuitBoard;
-    public static Item OpticGlass;
-    public static Item Cloth;
-    public static Item TanCloth;
-    public static Item GreenCloth;
-    public static Item Inductor;
-    public static Item Transistor;
-    public static Item Resistor;
-    public static Item Diode;
-    public static Item Capacitor;
-    public static Item CopperWiring;
-    public static Item Piston;
-    public static Item LaserPointer;
-    public static Item AluminumPlate;
-    public static Item SteelPlate;
-    public static Item BigSteelPlate;
-    public static Item MiniSteelPlate;
-    public static Item MetalComponents;
-    public static Item Plastic;
-    public static Item Backpack;
-    */
-
-
-    // I cannot figure out for the life of me why moving the init classes to the init() instead of the preInit() makes the game die, but I have no choice but to leave it here for now.
     public void preInit(final MWC mod) {
         MWC.modContext.preInit(mod);
-
-        UniversalSoundRegistry.init();
-        UniversalSoundLookup.initialize(MWC.modContext);
 
         // Forcing Item Initialization here, at the very least the variables, before they get registered normally on the init() (@SubscribeEvent) phase.
         MWCItems.init();
@@ -61,7 +34,7 @@ public class CommonProxy {
         DataSerializers.registerSerializer(VehicleDataSerializer.SERIALIZER);
         DataSerializers.registerSerializer(VehiclePhysSerializer.SERIALIZER);
 
-        // Special object initialization
+        // Special object initialization (Magic Mag)
         SpecialAttachments.init(MWC.modContext);
 
         Backpacks.createEquipment(MWC.modContext);
@@ -79,9 +52,6 @@ public class CommonProxy {
         Grenades.init(this);
         CustomSpawnEggs.init(this);
 
-        TurretBaseFactory.createTileEntity(MWC.modContext);
-        TileEntities.createTileEntity(MWC.modContext);
-
         new TacticalTomahawkFactory().createMelee(this);
         new BaseballBatFactory().createMelee(this);
         new BaseballBatNailsFactory().createMelee(this);
@@ -92,6 +62,12 @@ public class CommonProxy {
 
     public void init(final MWC mod) {
         MWC.modContext.init(mod);
+
+        UniversalSoundRegistry.init();
+        UniversalSoundLookup.initialize(MWC.modContext);
+
+        TurretBaseFactory.createTileEntity(MWC.modContext);
+        TileEntities.createTileEntity(MWC.modContext);
 
         Entities.init(MWC.modContext);
         Vehicles.init(MWC.modContext);

--- a/src/main/java/com/paneedah/mwc/skins/GunSkins.java
+++ b/src/main/java/com/paneedah/mwc/skins/GunSkins.java
@@ -7,6 +7,7 @@ import com.google.gson.stream.JsonReader;
 import com.paneedah.mwc.MWC;
 import com.paneedah.weaponlib.CommonRegistry;
 import com.paneedah.weaponlib.ItemSkin;
+import com.paneedah.weaponlib.ModContext;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import org.apache.commons.io.FileUtils;
@@ -33,61 +34,61 @@ public class GunSkins {
 
     public static HashMap<String, CustomSkin> customSkins = new HashMap<>();
 
-    public static void init(Object mod) {
+    public static void init(ModContext modContext) {
         GunSkins.WoodlandCamo = new ItemSkin.Builder()
                 .withTextureVariant("woodlandcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("WoodlandCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.WoodlandCamo);
 
         GunSkins.PinkCamo = new ItemSkin.Builder()
                 .withTextureVariant("pinkcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("PinkCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.PinkCamo);
 
         GunSkins.ArcticCamo = new ItemSkin.Builder()
                 .withTextureVariant("arcticcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("ArcticCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.ArcticCamo);
 
         GunSkins.BlueCamo = new ItemSkin.Builder()
                 .withTextureVariant("bluecamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("BlueCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.BlueCamo);
 
         GunSkins.Unit01Camo = new ItemSkin.Builder()
                 .withTextureVariant("unit01camo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("Unit01Camo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.Unit01Camo);
 
         GunSkins.BloodForestCamo = new ItemSkin.Builder()
                 .withTextureVariant("bloodforestcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("BloodForestCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.BloodForestCamo);
 
         GunSkins.DiamondCamo = new ItemSkin.Builder()
                 .withTextureVariant("diamondcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("DiamondCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.DiamondCamo);
 
         GunSkins.GoldCamo = new ItemSkin.Builder()
                 .withTextureVariant("goldcamo")
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withName("GoldCamo")
-                .build(MWC.modContext, ItemSkin.class);
+                .build(modContext, ItemSkin.class);
         CommonRegistry.gunSkins.add(GunSkins.GoldCamo);
 
         File customSkinsDir = new File("./config/mwc/skins");
@@ -116,7 +117,7 @@ public class GunSkins {
                             .withTextureVariant("customskin_" + skinName)
                             .withCreativeTab(MWC.ATTACHMENTS_TAB)
                             .withName(skinName)
-                            .build(MWC.modContext, ItemSkin.class);
+                            .build(modContext, ItemSkin.class);
                     CommonRegistry.gunSkins.add(skin);
                     LOGGER.info("Registered custom gun skin: " + skinName);
                 }
@@ -155,7 +156,7 @@ public class GunSkins {
                     .withTextureVariant("customskin_" + name.replace(".png", ""))
                     .withCreativeTab(MWC.ATTACHMENTS_TAB)
                     .withName(name.replace(".png", ""))
-                    .build(MWC.modContext, ItemSkin.class);
+                    .build(modContext, ItemSkin.class);
             CommonRegistry.gunSkins.add(skin);
             LOGGER.info("Registered custom gun skin: " + name);
         }

--- a/src/main/java/com/paneedah/mwc/vehicle/AudiS4Factory.java
+++ b/src/main/java/com/paneedah/mwc/vehicle/AudiS4Factory.java
@@ -1,6 +1,5 @@
 package com.paneedah.mwc.vehicle;
 
-import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.models.*;
 import com.paneedah.mwc.vehicle.engines.AudiS4Engine;
 import com.paneedah.weaponlib.ModContext;

--- a/src/main/java/com/paneedah/mwc/vehicle/Vehicles.java
+++ b/src/main/java/com/paneedah/mwc/vehicle/Vehicles.java
@@ -1,29 +1,28 @@
 package com.paneedah.mwc.vehicle;
 
-import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.models.VehicleKey;
 import com.paneedah.mwc.models.VehicleLock;
-import com.paneedah.mwc.proxies.CommonProxy;
+import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.render.QRL;
 import com.paneedah.weaponlib.vehicle.AccessibleVehicleGUI;
 import com.paneedah.weaponlib.vehicle.GeneralVehicleSounds;
 
 public class Vehicles {
 
-    public static void init(CommonProxy commonProxy) {
+    public static void init(ModContext modContext) {
 
         // Panda: Is this still the case? I don't think so.
 
         // due to the fact that advanced warfare cannot be accessed from
         // weaponlib, here are things that need to be set from this end.
-        GeneralVehicleSounds.setup(MWC.modContext);
+        GeneralVehicleSounds.setup(modContext);
         AccessibleVehicleGUI.remotelySetModels(new VehicleKey(), new VehicleLock(),
                 QRL.quickLoc("gui", "vehiclekey"), QRL.quickLoc("gui", "keylock"));
 
-        //new SampleVehicleFactory().createVehicle(MWC.modContext);
-        new AudiS4Factory().createVehicle(MWC.modContext);
-        new McLarenSennaFactory().createVehicle(MWC.modContext);
-        new AE86TruenoFactory().createVehicle(MWC.modContext);
-        new ATVFactory().createVehicle(MWC.modContext);
+        //new SampleVehicleFactory().createVehicle(modContext);
+        new AudiS4Factory().createVehicle(modContext);
+        new McLarenSennaFactory().createVehicle(modContext);
+        new AE86TruenoFactory().createVehicle(modContext);
+        new ATVFactory().createVehicle(modContext);
     }
 }

--- a/src/main/java/com/paneedah/mwc/weapons/Attachments.java
+++ b/src/main/java/com/paneedah/mwc/weapons/Attachments.java
@@ -545,7 +545,7 @@ public class Attachments {
 
     public static ItemAttachment<Weapon> MAC10Action;
 
-    public static void init(Object mod) {
+    public static void init(ModContext modContext) {
 
         G11HandguardK1 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -580,7 +580,7 @@ public class Attachments {
                     }
                 })
                 .withName("G11HandguardK1").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G11HandguardK2 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -615,7 +615,7 @@ public class Attachments {
                     }
                 })
                 .withName("G11HandguardK2").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 
         FABDefenseMount = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
@@ -654,7 +654,7 @@ public class Attachments {
                     }
                 })
                 .withName("FABDefenseMount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAS21Mount = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -694,7 +694,7 @@ public class Attachments {
                     }
                 })
                 .withName("MAS21Mount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P90Swordfish = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -737,7 +737,7 @@ public class Attachments {
                     }
                 })
                 .withName("P90swordfish").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P90DefaultKit = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -772,7 +772,7 @@ public class Attachments {
                     }
                 })
                 .withName("P90DefaultKit").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P90Terminator = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -807,7 +807,7 @@ public class Attachments {
                     }
                 })
                 .withName("P90Terminator").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -845,7 +845,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarHHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -883,7 +883,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarHHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarMidWestIndustriesHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -924,7 +924,7 @@ public class Attachments {
                 .withName("ScarMidWestIndustriesHandGuard")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarMLOKHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -964,7 +964,7 @@ public class Attachments {
                 .withName("ScarMLOKHandguard")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIG556Handguard = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.GUARD)
@@ -1005,7 +1005,7 @@ public class Attachments {
                 .withName("SIG556Handguard")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIG556HandguardRailed = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.GUARD)
@@ -1047,7 +1047,7 @@ public class Attachments {
                 .withName("SIG556HandguardRailed")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIG556HandguardKA = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.GUARD)
@@ -1089,7 +1089,7 @@ public class Attachments {
                 .withName("SIG556HandguardKA")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIG556Grip = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -1130,7 +1130,7 @@ public class Attachments {
                 .withName("SIG556Grip")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarLReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1168,7 +1168,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarLReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KrissVectorReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1206,7 +1206,7 @@ public class Attachments {
                     }
                 })
                 .withName("KrissVectorReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Vector556Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1247,7 +1247,7 @@ public class Attachments {
                     }
                 })
                 .withName("KrissVector556Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VectorMk1ModularHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1286,7 +1286,7 @@ public class Attachments {
                     }
                 })
                 .withName("VectorMk1ModularHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VectorCarbineHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1325,7 +1325,7 @@ public class Attachments {
                     }
                 })
                 .withName("VectorCarbineHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VectorTapedGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1365,7 +1365,7 @@ public class Attachments {
                     }
                 })
                 .withName("VectorTapedGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Origin12Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1406,7 +1406,7 @@ public class Attachments {
                     }
                 })
                 .withName("Origin12Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HKS20Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1443,7 +1443,7 @@ public class Attachments {
                     }
                 })
                 .withName("HKS20Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington700Chassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1478,7 +1478,7 @@ public class Attachments {
                     }
                 })
                 .withName("Remington700Chassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington700APACChassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1513,7 +1513,7 @@ public class Attachments {
                     }
                 })
                 .withName("Remington700APACChassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington700MDTXRSChassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1548,7 +1548,7 @@ public class Attachments {
                     }
                 })
                 .withName("Remington700MDTXRSChassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SSG08Chassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1584,7 +1584,7 @@ public class Attachments {
                     }
                 })
                 .withName("SSG08Chassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ARX160Chassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1623,7 +1623,7 @@ public class Attachments {
                     }
                 })
                 .withName("ARX160Chassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G2ContenderBarrelShort = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1661,7 +1661,7 @@ public class Attachments {
                     }
                 })
                 .withName("G2ContenderBarrelShort").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G2ContenderBarrelLong = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1700,7 +1700,7 @@ public class Attachments {
                     }
                 })
                 .withName("G2ContenderBarrelLong").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G2ContenderGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1736,7 +1736,7 @@ public class Attachments {
                     }
                 })
                 .withName("G2ContenderGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G2ContenderStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1772,7 +1772,7 @@ public class Attachments {
                     }
                 })
                 .withName("G2ContenderStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Origin12Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1811,7 +1811,7 @@ public class Attachments {
                     }
                 })
                 .withName("Origin12Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HKS20Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1846,7 +1846,7 @@ public class Attachments {
                     }
                 })
                 .withName("HKS20Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Origin12Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1886,7 +1886,7 @@ public class Attachments {
                     }
                 })
                 .withName("Origin12Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HKS20Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1922,7 +1922,7 @@ public class Attachments {
                     }
                 })
                 .withName("HKS20Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1963,7 +1963,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRHandGuardBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2005,7 +2005,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRHandGuardBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRWEMSKHandGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2044,7 +2044,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRWEMSKHandguardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRPrecisionHandGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2082,7 +2082,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRPrecisionHandGuardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRSBRHandGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2120,7 +2120,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRSBRHandGuardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRPolymerHandGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2158,7 +2158,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRPolymerHandguardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRSquareDropHandguardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2196,7 +2196,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRSquareDropHandguardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Type20Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2234,7 +2234,7 @@ public class Attachments {
                     }
                 })
                 .withName("Type20Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2272,7 +2272,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerMatrixArmsHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2310,7 +2310,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerMatrixArmsHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M60HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2345,7 +2345,7 @@ public class Attachments {
                     }
                 })
                 .withName("M60HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M60E4HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2383,7 +2383,7 @@ public class Attachments {
                     }
                 })
                 .withName("M60E4Guard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2418,7 +2418,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk48HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2454,7 +2454,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk48HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249UpperHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2489,7 +2489,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249UpperHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk48UpperHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2527,7 +2527,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk48UpperHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         StonerHANDGUARD = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2564,7 +2564,7 @@ public class Attachments {
                     }
                 })
                 .withName("StonerHANDGUARD").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGA1handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2599,7 +2599,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGA1").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGA2handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2635,7 +2635,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGA2handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGA3handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2671,7 +2671,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGA3handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         EF88Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2707,7 +2707,7 @@ public class Attachments {
                     }
                 })
                 .withName("EF88Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGDefaultKit = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2742,7 +2742,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGDefaultKit").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGParaConversion = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2777,7 +2777,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGParaConversion").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGA3extGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2817,7 +2817,7 @@ public class Attachments {
                     }
                 })
                 .withName("AUGA3extGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1CarbineBody = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2852,7 +2852,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1CarbineBody").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1A1CarbineBody = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2887,7 +2887,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1A1CarbineBody").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1CarbineHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2922,7 +2922,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1CarbineHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1CarbineVentilatedHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2957,7 +2957,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1CarbineVentilatedHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1CarbineScoutHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -2993,7 +2993,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1ScoutCarbineHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G3A1Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3032,7 +3032,7 @@ public class Attachments {
                     }
                 })
                 .withName("G3A1Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G3HandguardRailed = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3074,7 +3074,7 @@ public class Attachments {
                     }
                 })
                 .withName("G3HandguardRailed").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3109,7 +3109,7 @@ public class Attachments {
                     }
                 })
                 .withName("DSR1Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1HandguardRailed = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3144,7 +3144,7 @@ public class Attachments {
                     }
                 })
                 .withName("DSR1HandguardRailed").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1Barrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3179,7 +3179,7 @@ public class Attachments {
                     }
                 })
                 .withName("DSR1Barrel").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1BarrelLong = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3214,7 +3214,7 @@ public class Attachments {
                     }
                 })
                 .withName("DSR1BarrelLong").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M14Body = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3254,7 +3254,7 @@ public class Attachments {
                     }
                 })
                 .withName("M14Body").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M14SOCOMChassis = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3295,7 +3295,7 @@ public class Attachments {
                     }
                 })
                 .withName("M14DMRSocomChassis").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk14TanBody = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3336,7 +3336,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk14TanBody").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk14SnowBody = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3377,7 +3377,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk14SnowBody").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk14BlackBody = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3418,7 +3418,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk14BlackBody").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M14Cover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3458,7 +3458,7 @@ public class Attachments {
                     }
                 })
                 .withName("M14Cover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M14TriRailCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3501,7 +3501,7 @@ public class Attachments {
                     }
                 })
                 .withName("M14TriRailCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M14Rail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3540,7 +3540,7 @@ public class Attachments {
                     }
                 })
                 .withName("M14Rail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3578,7 +3578,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarRetractableStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3616,7 +3616,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarRetractableStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarAdapterStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3658,7 +3658,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarAdapterStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScarHStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3696,7 +3696,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScarHStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VectorStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3735,7 +3735,7 @@ public class Attachments {
                     }
                 })
                 .withName("VectorStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VectorStockAdapter = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3775,7 +3775,7 @@ public class Attachments {
                     }
                 })
                 .withName("VectorStockAdapter").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UMP45Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3810,7 +3810,7 @@ public class Attachments {
                     }
                 })
                 .withName("UMP45Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UMP9Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3845,7 +3845,7 @@ public class Attachments {
                     }
                 })
                 .withName("UMP9Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UMP45Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3880,7 +3880,7 @@ public class Attachments {
                     }
                 })
                 .withName("UMP45Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAC10Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3918,7 +3918,7 @@ public class Attachments {
                     }
                 })
                 .withName("MAC10Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAC21Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3957,7 +3957,7 @@ public class Attachments {
                     }
                 })
                 .withName("MAC21Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -3995,7 +3995,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRStockBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4033,7 +4033,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRStockBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRFixedStockTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4071,7 +4071,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRFixedStockTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRPRSStockTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4109,7 +4109,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRPRSStockTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRLongRangeStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4148,7 +4148,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRLongRangeStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRPDWStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4186,7 +4186,7 @@ public class Attachments {
                     }
                 })
                 .withName("ACRPDWStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1014Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4221,7 +4221,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1014Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1014Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4256,7 +4256,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1014Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4BenelliStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4291,7 +4291,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4BenelliStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Spas12Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4326,7 +4326,7 @@ public class Attachments {
                     }
                 })
                 .withName("Spas12Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4361,7 +4361,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249ParaStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4396,7 +4396,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249ParaStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249MilspecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4434,7 +4434,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249MilspecStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M249HK416Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4472,7 +4472,7 @@ public class Attachments {
                     }
                 })
                 .withName("M249Hk416Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UTGTriRailHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4514,7 +4514,7 @@ public class Attachments {
                     }
                 })
                 .withName("UTGTriRailHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5BMHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4556,7 +4556,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5BMHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MIMP5MHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4594,7 +4594,7 @@ public class Attachments {
                     }
                 })
                 .withName("MIMP5MHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScorpionHandguardShort = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4636,7 +4636,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScorpionEVO3A1HandguardShort").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScorpionHandguardLong = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4675,7 +4675,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScorpionEVO3A1HandguardLong").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MIMP5TRRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4714,7 +4714,7 @@ public class Attachments {
                     }
                 })
                 .withName("MIMP5TRRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MIMP5MRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4753,7 +4753,7 @@ public class Attachments {
                     }
                 })
                 .withName("MIMP5MRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ShotgunRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4789,7 +4789,7 @@ public class Attachments {
                     }
                 })
                 .withName("ShotgunRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Kar98Krail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4825,7 +4825,7 @@ public class Attachments {
                     }
                 })
                 .withName("Kar98Krail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M60Rail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4861,7 +4861,7 @@ public class Attachments {
                     }
                 })
                 .withName("M60Rail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16A1ScopeMount = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4901,7 +4901,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16A1ScopeMount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FamasF1ScopeMount = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4941,7 +4941,7 @@ public class Attachments {
                     }
                 })
                 .withName("FamasF1ScopeMount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16A1PicatinnyRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -4981,7 +4981,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16A1PicatinnyRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FamasF1PicatinnyRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -5023,7 +5023,7 @@ public class Attachments {
                     }
                 })
                 .withName("FamasF1PicatinnyRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         NGSWRRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -5059,7 +5059,7 @@ public class Attachments {
                     }
                 })
                 .withName("NGSWRRail").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RailRiser = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -5096,7 +5096,7 @@ public class Attachments {
                     }
                 })
                 .withName("RailRiser").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1911Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5135,7 +5135,7 @@ public class Attachments {
                 })
                 .withName("M1911Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1911Body = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5172,7 +5172,7 @@ public class Attachments {
                 })
                 .withName("M1911Body")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M191144MagSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5211,7 +5211,7 @@ public class Attachments {
                 })
                 .withName("M191144MagSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M191144MagBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5248,7 +5248,7 @@ public class Attachments {
                 })
                 .withName("M191144MagBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M9A1Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5290,7 +5290,7 @@ public class Attachments {
                 })
                 .withName("M9A1Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M9A1Body = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5330,7 +5330,7 @@ public class Attachments {
                 })
                 .withName("M9A1Body")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SamuraiEdgeSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5373,7 +5373,7 @@ public class Attachments {
                 })
                 .withName("SamuraiEdgeSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SamuraiEdgeBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5414,7 +5414,7 @@ public class Attachments {
                 })
                 .withName("SamuraiEdgeBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SamuraiEdgeMount = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.GUARD)
@@ -5452,7 +5452,7 @@ public class Attachments {
                 })
                 .withName("SamuraiEdgeMount")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5488,7 +5488,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5525,7 +5525,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleLongBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5562,7 +5562,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleLongBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleBodyGolden = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5599,7 +5599,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleBodyGolden")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleSlideGolden = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5635,7 +5635,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleSlideGolden")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleBodyBlack = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5672,7 +5672,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleBodyBlack")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DesertEagleSlideBlack = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5708,7 +5708,7 @@ public class Attachments {
                 })
                 .withName("DesertEagleSlideBlack")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19Body = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5748,7 +5748,7 @@ public class Attachments {
                 })
                 .withName("Glock19Body")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 //        Glock18CBody = new AttachmentBuilder<Weapon>()
 //                .withCategory(AttachmentCategory.BACKGRIP)
@@ -5785,7 +5785,7 @@ public class Attachments {
 //                })
 //                .withName("Glock18CBody")
 //                .withRenderablePart().withTextureName("Dummy.png")
-//                .build(MWC.modContext);
+//                .build(modContext);
 
         Glock19XBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5825,7 +5825,7 @@ public class Attachments {
                 })
                 .withName("Glock19XBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19RazorbackBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -5865,7 +5865,7 @@ public class Attachments {
                 })
                 .withName("GlockRazorbackBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5907,7 +5907,7 @@ public class Attachments {
                 })
                 .withName("Glock19Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock18CSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5949,7 +5949,7 @@ public class Attachments {
                 })
                 .withName("Glock18CSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock18CCNCSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -5991,7 +5991,7 @@ public class Attachments {
                 })
                 .withName("Glock18CCNCslide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19XSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6033,7 +6033,7 @@ public class Attachments {
                 })
                 .withName("Glock19XSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19RazorbackSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6075,7 +6075,7 @@ public class Attachments {
                 })
                 .withName("GlockRazorbackSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19RockSlideOlive = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6117,7 +6117,7 @@ public class Attachments {
                 })
                 .withName("Glock19RockslideOlive")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Glock19GhostPrecisionSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6159,7 +6159,7 @@ public class Attachments {
                 })
                 .withName("Glock19GhostPrecisionSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2Body = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -6199,7 +6199,7 @@ public class Attachments {
                 })
                 .withName("SCCYCPX2Body")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2BodyTan = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -6239,7 +6239,7 @@ public class Attachments {
                 })
                 .withName("SCCYCPX2BodyTan")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2GripTape = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.GUARD)
@@ -6280,7 +6280,7 @@ public class Attachments {
                 })
                 .withName("SCCYCPX2GripTape")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6322,7 +6322,7 @@ public class Attachments {
                 })
                 .withName("SCCYCPX2Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2BSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6364,7 +6364,7 @@ public class Attachments {
                 })
                 .withName("SCCYCPX2BSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P226Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6406,7 +6406,7 @@ public class Attachments {
                 })
                 .withName("P226Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FiveSevenSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6445,7 +6445,7 @@ public class Attachments {
                 })
                 .withName("FiveSevenSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MakarovBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -6485,7 +6485,7 @@ public class Attachments {
                 })
                 .withName("MakarovBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MakarovSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6527,7 +6527,7 @@ public class Attachments {
                 })
                 .withName("MakarovPMSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MakarovPBSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6569,7 +6569,7 @@ public class Attachments {
                 })
                 .withName("MakarovPBSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP443Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6609,7 +6609,7 @@ public class Attachments {
                 })
                 .withName("MP443Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MakarovPBBody = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.BACKGRIP)
@@ -6652,7 +6652,7 @@ public class Attachments {
                 })
                 .withName("MakarovPBBody")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAC10Body = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6690,7 +6690,7 @@ public class Attachments {
                     }
                 })
                 .withName("MAC10Body").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAC10Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -6731,7 +6731,7 @@ public class Attachments {
                 })
                 .withName("MAC10Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5NavyHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6769,7 +6769,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5NavyHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5A5HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6807,7 +6807,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5A5HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5SDHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6846,7 +6846,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5SDHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5HOGUEGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6884,7 +6884,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5HOGUEGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         GlockHOGUEGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6919,7 +6919,7 @@ public class Attachments {
                     }
                 })
                 .withName("GlockHogueGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         GlockHOGUEGripTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6957,7 +6957,7 @@ public class Attachments {
                     }
                 })
                 .withName("GlockHogueGripTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         APSGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -6996,7 +6996,7 @@ public class Attachments {
                     }
                 })
                 .withName("APSGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         APSStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7035,7 +7035,7 @@ public class Attachments {
                     }
                 })
                 .withName("APSStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAC10Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7073,7 +7073,7 @@ public class Attachments {
                     }
                 })
                 .withName("MAC10Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7111,7 +7111,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5A3Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7149,7 +7149,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5A3Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5A4Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7187,7 +7187,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5A4Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP5MilspecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7231,7 +7231,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP5StockAdapter").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         LVOAVHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7273,7 +7273,7 @@ public class Attachments {
                     }
                 })
                 .withName("LVOAVHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AR15HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7313,7 +7313,7 @@ public class Attachments {
                     }
                 })
                 .withName("AR15FN15Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M38HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7355,7 +7355,7 @@ public class Attachments {
                     }
                 })
                 .withName("M38HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416HandGuardBlackAndTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7397,7 +7397,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416HandGuardBlackAndTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK417Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7436,7 +7436,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK417Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK417HandguardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7475,7 +7475,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK417HandguardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk18HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7517,7 +7517,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk18HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Mk18HandGuardBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7559,7 +7559,7 @@ public class Attachments {
                     }
                 })
                 .withName("Mk18HandGuardBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Block2SOCOMHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7602,7 +7602,7 @@ public class Attachments {
                     }
                 })
                 .withName("Block2SOCOMHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FSSTacLiteHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7644,7 +7644,7 @@ public class Attachments {
                     }
                 })
                 .withName("FSSTacLiteHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4MagpulHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7682,7 +7682,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4MagpulHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4MagpulHandGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7720,7 +7720,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4MagpulHandGuardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7759,7 +7759,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7798,7 +7798,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         C8SFWReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7834,7 +7834,7 @@ public class Attachments {
                     }
                 })
                 .withName("C8SFWReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VLTORReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7873,7 +7873,7 @@ public class Attachments {
                     }
                 })
                 .withName("VLTORReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AR57Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7909,7 +7909,7 @@ public class Attachments {
                     }
                 })
                 .withName("AR57Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK417Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7945,7 +7945,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK417Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK417ReceiverTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -7981,7 +7981,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK417ReceiverTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M110Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8020,7 +8020,7 @@ public class Attachments {
                     }
                 })
                 .withName("M110Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Z10Receiver = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.RECEIVER)
@@ -8058,7 +8058,7 @@ public class Attachments {
                     }
                 })
                 .withName("Z10Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Beowulf50CalReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8098,7 +8098,7 @@ public class Attachments {
                     }
                 })
                 .withName("Beowulf50CalReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         S710Receiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8133,7 +8133,7 @@ public class Attachments {
                     }
                 })
                 .withName("S710Receiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         CZ805BrenReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8171,7 +8171,7 @@ public class Attachments {
                     }
                 })
                 .withName("CZ805BrenReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8207,7 +8207,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerReceiverBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8243,7 +8243,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerReceiverBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerKnightsReceiver = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8279,7 +8279,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerKnightsReceiver").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerKnightsReceiverBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8315,7 +8315,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerKnightsReceiverBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Placeholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8337,7 +8337,7 @@ public class Attachments {
                     }
                 })
                 .withName("Placeholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FamasPlaceholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8359,7 +8359,7 @@ public class Attachments {
                     }
                 })
                 .withName("FamasPlaceholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         APC9Placeholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8381,7 +8381,7 @@ public class Attachments {
                     }
                 })
                 .withName("APC9Placeholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P90Placeholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8403,7 +8403,7 @@ public class Attachments {
                     }
                 })
                 .withName("P90Placeholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         PistolPlaceholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8425,7 +8425,7 @@ public class Attachments {
                     }
                 })
                 .withName("PistolPlaceholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         GripPlaceholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8447,7 +8447,7 @@ public class Attachments {
                     }
                 })
                 .withName("GripPlaceholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M40A6GripPlaceholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8469,7 +8469,7 @@ public class Attachments {
                     }
                 })
                 .withName("M40A6GripPlaceholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         LaserPlaceholder = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withModel(new com.paneedah.mwc.models.M4Receiver(), "gun.png")
@@ -8491,7 +8491,7 @@ public class Attachments {
                     }
                 })
                 .withName("LaserPlaceholder").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8529,7 +8529,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AR57Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8568,7 +8568,7 @@ public class Attachments {
                     }
                 })
                 .withName("AR57Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         NTW20HandguardRAIL = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8604,7 +8604,7 @@ public class Attachments {
                     }
                 })
                 .withName("NTW20Guard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8642,7 +8642,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16A1Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8680,7 +8680,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16A1Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4CarbineHandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8722,7 +8722,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4CarbineHandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16A4HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8764,7 +8764,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16A4HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M110Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8806,7 +8806,7 @@ public class Attachments {
                     }
                 })
                 .withName("M110Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Z10Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8846,7 +8846,7 @@ public class Attachments {
                     }
                 })
                 .withName("Z10Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AR10SuperSASSHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8888,7 +8888,7 @@ public class Attachments {
                     }
                 })
                 .withName("AR10SuperSASSHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         S710Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -8923,7 +8923,7 @@ public class Attachments {
                     }
                 })
                 .withName("S710Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
         SIGMCXHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
                 .withModel(new com.paneedah.mwc.models.SIGMCXHandguard(), "sigmcx.png")
@@ -8963,7 +8963,7 @@ public class Attachments {
                     }
                 })
                 .withName("SIGMCXHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIGMCXHandguardShort = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9001,7 +9001,7 @@ public class Attachments {
                     }
                 })
                 .withName("SIGMCXHandguardShort").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MPXHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9040,7 +9040,7 @@ public class Attachments {
                     }
                 })
                 .withName("MPXHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MPXHandguardExtended = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9079,7 +9079,7 @@ public class Attachments {
                     }
                 })
                 .withName("MPXHandguardExtended").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MPXHandguardRailed = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9118,7 +9118,7 @@ public class Attachments {
                     }
                 })
                 .withName("MPXHandguardRailed").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         K2C1Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9158,7 +9158,7 @@ public class Attachments {
                     }
                 })
                 .withName("K2C1Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HeraArmsGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9196,7 +9196,7 @@ public class Attachments {
                     }
                 })
                 .withName("HeraArmsGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9234,7 +9234,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4GripTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9272,7 +9272,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4GripTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SOCOM_Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
 //                .withCreativeTab(MWC.AttachmentsTab)
@@ -9307,7 +9307,7 @@ public class Attachments {
                     }
                 })
                 .withName("SOCOM_Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4GripGray = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9345,7 +9345,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4GripGray").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9383,7 +9383,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416GripTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9421,7 +9421,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416GripTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M110Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9459,7 +9459,7 @@ public class Attachments {
                     }
                 })
                 .withName("M110Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         S710TricunGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9494,7 +9494,7 @@ public class Attachments {
                     }
                 })
                 .withName("S710TricunGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         K2C1Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9532,7 +9532,7 @@ public class Attachments {
                     }
                 })
                 .withName("K2C1Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK47Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9571,7 +9571,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK47Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK101Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9609,7 +9609,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK101Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKErgoGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9647,7 +9647,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKErgoGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKErgoGripGreen = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9685,7 +9685,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKErgoGripGreen").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKErgoGripTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9723,7 +9723,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKErgoGripTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9761,7 +9761,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12ErgoGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9799,7 +9799,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12ErgoGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9835,7 +9835,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerStockBlack = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9871,7 +9871,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerStockBlack").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G3Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9911,7 +9911,7 @@ public class Attachments {
                     }
                 })
                 .withName("G3Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP7Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9951,7 +9951,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP7Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP7MilSpecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -9996,7 +9996,7 @@ public class Attachments {
                     }
                 })
                 .withName("MP7MilSpecStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK47Stock = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.STOCK)
@@ -10040,7 +10040,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK47stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DragunovGripStock = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.STOCK)
@@ -10084,7 +10084,7 @@ public class Attachments {
                     }
                 })
                 .withName("DragunovGripStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Dragunov98Stock = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.STOCK)
@@ -10127,7 +10127,7 @@ public class Attachments {
                     }
                 })
                 .withName("Dragunov98Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RPKStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10162,7 +10162,7 @@ public class Attachments {
                     }
                 })
                 .withName("RPKstock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK101Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10200,7 +10200,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK101Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK74Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10238,7 +10238,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK74Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10276,7 +10276,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12ZenitcoStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10314,7 +10314,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12ZenitcoStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10353,7 +10353,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSVintorezStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ASValStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10392,7 +10392,7 @@ public class Attachments {
                     }
                 })
                 .withName("ASValStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezMilspecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10436,7 +10436,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSVintorezMilspecStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         CollapsableMOEStock = new AttachmentBuilder<Weapon>()
                 .withRenderablePart()
@@ -10476,7 +10476,7 @@ public class Attachments {
                     }
                 })
                 .withName("CollapsableMOEStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         CollapsableMOEStockGreen = new AttachmentBuilder<Weapon>()
                 .withRenderablePart()
@@ -10516,7 +10516,7 @@ public class Attachments {
                     }
                 })
                 .withName("CollapsableMOEStockGreen").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MagpulCTRStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10555,7 +10555,7 @@ public class Attachments {
                     }
                 })
                 .withName("MagpulCTRStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MagpulCTRStockTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10594,7 +10594,7 @@ public class Attachments {
                     }
                 })
                 .withName("MagpulCTRStockTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MilSpecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10633,7 +10633,7 @@ public class Attachments {
                     }
                 })
                 .withName("MilSpecStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         CZ805BrenStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10672,7 +10672,7 @@ public class Attachments {
                     }
                 })
                 .withName("CZ805BrenStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SIGMCXStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10711,7 +10711,7 @@ public class Attachments {
                     }
                 })
                 .withName("SIGMCXStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         C8Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
 //                .withCreativeTab(MWC.AttachmentsTab)
@@ -10747,7 +10747,7 @@ public class Attachments {
                     }
                 })
                 .withName("C8Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MilSpecStockTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10786,7 +10786,7 @@ public class Attachments {
                     }
                 })
                 .withName("MilSpecStockTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HeraArmsStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10825,7 +10825,7 @@ public class Attachments {
                     }
                 })
                 .withName("HeraArmsStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10864,7 +10864,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SOCOM_Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
 //                .withCreativeTab(MWC.AttachmentsTab)
@@ -10900,7 +10900,7 @@ public class Attachments {
                     }
                 })
                 .withName("SOCOM_Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10938,7 +10938,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416StockTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -10977,7 +10977,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416StockTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M110Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11016,7 +11016,7 @@ public class Attachments {
                     }
                 })
                 .withName("M110Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         PRSPrecisionStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11055,7 +11055,7 @@ public class Attachments {
                     }
                 })
                 .withName("ARPRSPrecisionStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK47HandleGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11094,7 +11094,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK47HandleGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DragunovHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11135,7 +11135,7 @@ public class Attachments {
                     }
                 })
                 .withName("DragunovHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Dragunov98Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11174,7 +11174,7 @@ public class Attachments {
                     }
                 })
                 .withName("Dragunov98Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK101HandGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11212,7 +11212,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK101HandGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK74Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11250,7 +11250,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK74Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKMagpulHandleGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11288,7 +11288,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKMagpulHandleGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKMagpulHandleGuardTan = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11326,7 +11326,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKMagpulHandleGuardTan").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MLOKHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11366,7 +11366,7 @@ public class Attachments {
                     }
                 })
                 .withName("MLOKHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MLOKExtendedHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11406,7 +11406,7 @@ public class Attachments {
                     }
                 })
                 .withName("MLOKExtendedHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK15HandleGuard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11445,7 +11445,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK15HandleGuard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12kalHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11484,7 +11484,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12kalHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RPK16Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11523,7 +11523,7 @@ public class Attachments {
                     }
                 })
                 .withName("RPK16handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11561,7 +11561,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12BHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11599,7 +11599,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12BHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KBP9A91Handguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11637,7 +11637,7 @@ public class Attachments {
                     }
                 })
                 .withName("KBP9A91Handguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KBP9A91CompactHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11675,7 +11675,7 @@ public class Attachments {
                     }
                 })
                 .withName("KBP9A91CompactHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KBP9A91KulaTacHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11713,7 +11713,7 @@ public class Attachments {
                     }
                 })
                 .withName("KBP9A91KulaTacHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11752,7 +11752,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSVintorezHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ASValHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11790,7 +11790,7 @@ public class Attachments {
                     }
                 })
                 .withName("ASValHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezTriRailMount = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11828,7 +11828,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSVintorezTriRailMount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK47DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11866,7 +11866,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK47Dustcover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DragunovDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11904,7 +11904,7 @@ public class Attachments {
                     }
                 })
                 .withName("DragunovDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Dragunov98DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11942,7 +11942,7 @@ public class Attachments {
                     }
                 })
                 .withName("Dragunov98DustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKMDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -11980,7 +11980,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKMDustcover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK101DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12018,7 +12018,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK101DustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VeprDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12057,7 +12057,7 @@ public class Attachments {
                     }
                 })
                 .withName("VeprDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK15DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12096,7 +12096,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK15DustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12134,7 +12134,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12DustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12BDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12172,7 +12172,7 @@ public class Attachments {
                     }
                 })
                 .withName("AK12BDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12210,7 +12210,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSVintorezDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSMDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12248,7 +12248,7 @@ public class Attachments {
                     }
                 })
                 .withName("VSSMDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALDustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12283,7 +12283,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALDustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SA58DustCover = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12319,7 +12319,7 @@ public class Attachments {
                     }
                 })
                 .withName("SA58DustCover").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.BACKGRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12354,7 +12354,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12389,7 +12389,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALStock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12424,7 +12424,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALPARAHandguard = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12460,7 +12460,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALPARAHandguard").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M4FrontSight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12502,7 +12502,7 @@ public class Attachments {
                     }
                 })
                 .withName("M4FrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M60FrontSight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12537,7 +12537,7 @@ public class Attachments {
                     }
                 })
                 .withName("M60FrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M38FrontSight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12577,7 +12577,7 @@ public class Attachments {
                     }
                 })
                 .withName("M38FrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416FrontSight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12625,7 +12625,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416FrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MBUSFrontSight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -12674,7 +12674,7 @@ public class Attachments {
                     }
                 })
                 .withName("MBUSFrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         LeupoldScope = new ItemScope.Builder()
                 .withOpticalZoom()
@@ -12732,7 +12732,7 @@ public class Attachments {
                     }
                 })
                 .withName("Leupold")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         PSO1 = new ItemScope.Builder()
                 .withSniperReticle(Reticles.RETICLE_PSO1)
@@ -12795,7 +12795,7 @@ public class Attachments {
                     }
                 })
                 .withName("PSO1")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         OKP7 = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.OKP)
@@ -12851,7 +12851,7 @@ public class Attachments {
                     }
                 })
                 .withName("okp7").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FMG9Sight = new ItemScope.Builder()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -12901,7 +12901,7 @@ public class Attachments {
                     }
                 })
                 .withName("fmg9carryhandle").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Reflex = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.REFLEX)
@@ -12970,7 +12970,7 @@ public class Attachments {
                     }
                 })
                 .withName("Reflex").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         BijiaReflex = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.BIJIA)
@@ -13038,7 +13038,7 @@ public class Attachments {
                     }
                 })
                 .withName("BijiaReflex").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MicroReflex = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.MICROREFLEX)
@@ -13113,7 +13113,7 @@ public class Attachments {
                     }
                 })
                 .withName("MicroReflex").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACOG = new ItemScope.Builder()
                 .withSniperReticle(Reticles.RETICLE_ACOG)
@@ -13199,7 +13199,7 @@ public class Attachments {
                 .withPivotPoint(-0.12079999459981924F, -1.4240000168085098F, -2.392400065904859F)
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Specter = new ItemScope.Builder()
                 .withSniperReticle(Reticles.RETICLE_SPECTRE)
@@ -13270,7 +13270,7 @@ public class Attachments {
                 })
                 .withName("Specter").withTextureName("Dummy.png")
                 .withPivotPoint(-0.12079999459981924F, -1.4240000168085098F, -2.392400065904859F)
-                .build(MWC.modContext);
+                .build(modContext);
 
         Holographic = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.HOLO_ONE)
@@ -13341,7 +13341,7 @@ public class Attachments {
                 })
                 .withName("Holographic2").withTextureName("Dummy.png")
                 .withPivotPoint(-0.12079999459981924F, -1.4240000168085098F, -2.392400065904859F)
-                .build(MWC.modContext);
+                .build(modContext);
 
         HolographicAlt = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.HOLO_ONE)
@@ -13411,7 +13411,7 @@ public class Attachments {
                     }
                 })
                 .withName("HolographicAlt").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         EotechHybrid2 = new ItemScope.Builder()
                 .withSniperReticle(Reticles.RETICLE_HOLO)
@@ -13489,7 +13489,7 @@ public class Attachments {
                     }
                 })
                 .withName("EotechHybrid2").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VortexRedux = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.VORTEX)
@@ -13558,7 +13558,7 @@ public class Attachments {
                     }
                 })
                 .withName("VortexSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MicroT1 = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.REFLEX)
@@ -13628,7 +13628,7 @@ public class Attachments {
                     }
                 })
                 .withName("MicroT1").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AimpointCompM2 = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.REFLEX)
@@ -13699,7 +13699,7 @@ public class Attachments {
                 })
                 .withName("AimpointCompM2").withTextureName("Dummy.png")
                 .withPivotPoint(-0.12079999459981924F, -1.4240000168085098F, -2.392400065904859F)
-                .build(MWC.modContext);
+                .build(modContext);
 
         AimpointCompM5 = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.REFLEX)
@@ -13769,7 +13769,7 @@ public class Attachments {
                     }
                 })
                 .withName("AimpointCompM5").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RMR = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.RMR)
@@ -13833,7 +13833,7 @@ public class Attachments {
                     }
                 })
                 .withName("RMRsight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Kobra = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.KOBRA)
@@ -13903,7 +13903,7 @@ public class Attachments {
                     }
                 })
                 .withName("Kobra").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KobraGen3 = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.KOBRA)
@@ -13973,7 +13973,7 @@ public class Attachments {
                     }
                 })
                 .withName("KobraGen3").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KobraMount = new ItemScope.Builder()
                 .withHolographicReticles(Reticles.KOBRA)
@@ -14029,7 +14029,7 @@ public class Attachments {
                     }
                 })
                 .withName("KobraMount").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HP = new ItemScope.Builder()
 //                .withNightVision()
@@ -14082,7 +14082,7 @@ public class Attachments {
                     }
                 })
                 .withName("HPScope").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         LeupoldRailScope = new ItemScope.Builder()
                 .withSniperReticle(Reticles.RETICLE_1)
@@ -14150,7 +14150,7 @@ public class Attachments {
                 })
                 .withName("LeupoldRailScope")
                 .withPivotPoint(-0.12079999459981924F, -1.4240000168085098F, -2.392400065904859F)
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         NightRaider = new ItemScope.Builder()
                 .withNightVision()
@@ -14218,7 +14218,7 @@ public class Attachments {
                 .withName("NightRaiderScope")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M2A1sight = new ItemScope.Builder()
                 .withOpticalZoom()
@@ -14271,7 +14271,7 @@ public class Attachments {
                     }
                 })
                 .withName("m2a1_sight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         F2000Scope = new ItemScope.Builder()
                 .withOpticalZoom()
@@ -14333,7 +14333,7 @@ public class Attachments {
                 .withName("F2000Scope")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M202scope = new ItemScope.Builder()
                 .withOpticalZoom()
@@ -14371,7 +14371,7 @@ public class Attachments {
                 .withName("M202scope")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGscope = new ItemScope.Builder()
                 .withOpticalZoom()
@@ -14433,7 +14433,7 @@ public class Attachments {
                 .withName("AUGscope")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer556x45 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SILENCER)
@@ -14474,7 +14474,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer556x45").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer545x39 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14514,7 +14514,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer545x39").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer762x39 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14554,7 +14554,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer762x39").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M32Barrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14591,7 +14591,7 @@ public class Attachments {
                 }).withName("M32Barrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870Pump = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14628,7 +14628,7 @@ public class Attachments {
                 }).withName("Remington870Pump")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870MagpulPump = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14665,7 +14665,7 @@ public class Attachments {
                 }).withName("Remington870MagpulPump")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870PoliceMagnumPump = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14702,7 +14702,7 @@ public class Attachments {
                 }).withName("Remington870PoliceMagnumPump")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870FABDefensePump = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GUARD)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14748,7 +14748,7 @@ public class Attachments {
                 }).withName("Remington870FABDefensePump")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14784,7 +14784,7 @@ public class Attachments {
                 }).withName("Remington870Stock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870PoliceMagnumStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14820,7 +14820,7 @@ public class Attachments {
                 }).withName("Remington870PoliceMagnumStock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870MilspecStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14869,7 +14869,7 @@ public class Attachments {
                 }).withName("Remington870MilSpecStock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870HK416Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14918,7 +14918,7 @@ public class Attachments {
                 }).withName("Remington870HK416StockStock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870SawedGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14954,7 +14954,7 @@ public class Attachments {
                 }).withName("Remington870SawedGrip")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870Barrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -14999,7 +14999,7 @@ public class Attachments {
                 }).withName("Remington870Barrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870PoliceMagnumBarrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15044,7 +15044,7 @@ public class Attachments {
                 }).withName("Remington870PoliceMagnumBarrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington870SawedOffBarrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RECEIVER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15089,7 +15089,7 @@ public class Attachments {
                 }).withName("Remington870SawedBarrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15125,7 +15125,7 @@ public class Attachments {
                 }).withName("KS23Stock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23RaptorGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15161,7 +15161,7 @@ public class Attachments {
                 }).withName("KS23RaptorGrip")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23MStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15197,7 +15197,7 @@ public class Attachments {
                 }).withName("KS23MStock")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23Barrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15234,7 +15234,7 @@ public class Attachments {
                 }).withName("KS23Barrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23ExtendedBarrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15271,7 +15271,7 @@ public class Attachments {
                 }).withName("KS23ExtendedBarrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RPKBarrel = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15317,7 +15317,7 @@ public class Attachments {
                 }).withName("RPKbarrel")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKIron = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.FRONTSIGHT)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15355,7 +15355,7 @@ public class Attachments {
                 }).withName("AKIron")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12Iron = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15393,7 +15393,7 @@ public class Attachments {
                 }).withName("AK12Iron")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SilencerPBS = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15435,7 +15435,7 @@ public class Attachments {
                 }).withName("SilencerPBS")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer9mm = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15479,7 +15479,7 @@ public class Attachments {
                 }).withName("Silencer9mm")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SamuraiEdgeSuppressor = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15521,7 +15521,7 @@ public class Attachments {
                 }).withName("SamuraiEdgeSuppressor")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer9x39mm = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15562,7 +15562,7 @@ public class Attachments {
                 }).withName("Silencer9x39mm")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SuppressorKBP9A91 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15603,7 +15603,7 @@ public class Attachments {
                 }).withName("KBP9A91Suppressor")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer45ACP = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15643,7 +15643,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("Silencer45ACP").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SilencerEABH = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15678,7 +15678,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("silencer_eabh").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer762x54 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15718,7 +15718,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer762x54").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer762x51 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15758,7 +15758,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer762x51").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer50BMG = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -15798,7 +15798,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer50BMG").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 
         Silencer556x39 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
@@ -15839,7 +15839,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer556x39").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 
         AKMIron = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SCOPE)
@@ -15890,7 +15890,7 @@ public class Attachments {
                     }
                 })
                 .withName("AKMIron").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         TritiumRearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -15937,7 +15937,7 @@ public class Attachments {
                     }
                 })
                 .withName("TritiumRearSights").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MBUSRearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -15985,7 +15985,7 @@ public class Attachments {
                     }
                 })
                 .withName("MBUSRearSights").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HK416RearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -16032,7 +16032,7 @@ public class Attachments {
                     }
                 })
                 .withName("HK416RearSights").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALRearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -16068,7 +16068,7 @@ public class Attachments {
                     }
                 })
                 .withName("FNFALRearSights").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M16A1RearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -16103,7 +16103,7 @@ public class Attachments {
                     }
                 })
                 .withName("M16A1RearSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         K2C1RearSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -16141,7 +16141,7 @@ public class Attachments {
                     }
                 })
                 .withName("K2C1RearSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScorpionRearSight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -16177,7 +16177,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScorpionRearSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ScorpionFrontSight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -16213,7 +16213,7 @@ public class Attachments {
                     }
                 })
                 .withName("ScorpionFrontSight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP7IronSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -16252,7 +16252,7 @@ public class Attachments {
                 })
                 .withName("MP7IronSights")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP7IronSightsStanding = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -16291,7 +16291,7 @@ public class Attachments {
                 })
                 .withName("MP7IronSightsStanding")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Kar98Ksight = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.RAILING)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16326,7 +16326,7 @@ public class Attachments {
                     }
                 })
                 .withName("Kar98Ksight").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK15ironsight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.SCOPE)
@@ -16365,7 +16365,7 @@ public class Attachments {
                 })
                 .withName("AK15ironsight")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12ironsight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.FRONTSIGHT)
@@ -16404,7 +16404,7 @@ public class Attachments {
                 })
                 .withName("AK12ironsight")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SilencerMP7 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16443,7 +16443,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("SilencerMP7").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer357 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16478,7 +16478,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("Silencer357").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer57x38 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16517,7 +16517,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("Silencer57x38").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 
         Silencer12Gauge = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
@@ -16557,7 +16557,7 @@ public class Attachments {
                         GL11.glScaled(0.4F, 0.4F, 0.4F);
                     }
                 }).withName("Silencer12Gauge").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 
         Silencer300AACBlackout = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
@@ -16598,7 +16598,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer300AACBlackout").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HoneyBadgerSilencer = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withModel(new com.paneedah.mwc.models.AACHoneyBadgerSilencer(), "gun.png")
@@ -16633,7 +16633,7 @@ public class Attachments {
                     }
                 })
                 .withName("HoneyBadgerSilencer").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Silencer65x39 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SILENCER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16673,7 +16673,7 @@ public class Attachments {
                     }
                 })
                 .withName("Silencer65x39").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Laser = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.LASER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16740,7 +16740,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("Laser").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Laser2 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.LASER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16797,7 +16797,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("Laser2").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SCCYCPX2Laser = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.LASER)
@@ -16849,7 +16849,7 @@ public class Attachments {
                 .withName("SCCYCPX2Laser")
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DanWessonLaser = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.LASER)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -16897,7 +16897,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("DanWessonLaser").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1928Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -16935,7 +16935,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1928Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1A1Grip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -16973,7 +16973,7 @@ public class Attachments {
                     }
                 })
                 .withName("M1A1Grip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Grip2 = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17032,7 +17032,7 @@ public class Attachments {
                     }
                 })
                 .withName("Grip2").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         JunoGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17081,7 +17081,7 @@ public class Attachments {
                     }
                 })
                 .withName("JunoGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         GlockStock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withRenderablePart()
@@ -17122,7 +17122,7 @@ public class Attachments {
                     }
                 })
                 .withName("Glock18Cstock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VP70Stock = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.STOCK)
                 .withRenderablePart()
@@ -17164,7 +17164,7 @@ public class Attachments {
                     }
                 })
                 .withName("VP70Stock").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AngledGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17222,7 +17222,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("AngledGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         StubbyGrip = new AttachmentBuilder<Weapon>()
                 .withRenderablePart()
@@ -17288,7 +17288,7 @@ public class Attachments {
                     }
                 })
                 .withName("StubbyGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VGrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17349,7 +17349,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("VGrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Bipod = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB).withModel(new com.paneedah.mwc.models.Bipod(), "bipod.png")
@@ -17403,7 +17403,7 @@ public class Attachments {
                     }
                 })
                 .withName("Bipod").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGgrip = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17443,7 +17443,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("AUGgrip").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         USPMatchCompensator = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.GRIP)
                 .withRenderablePart()
@@ -17483,7 +17483,7 @@ public class Attachments {
                 })
                 .withRenderablePart()
                 .withName("USPMatchCompensator").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
     }
 }

--- a/src/main/java/com/paneedah/mwc/weapons/AuxiliaryAttachments.java
+++ b/src/main/java/com/paneedah/mwc/weapons/AuxiliaryAttachments.java
@@ -2,10 +2,7 @@ package com.paneedah.mwc.weapons;
 
 import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.models.*;
-import com.paneedah.weaponlib.AttachmentBuilder;
-import com.paneedah.weaponlib.AttachmentCategory;
-import com.paneedah.weaponlib.ItemAttachment;
-import com.paneedah.weaponlib.Weapon;
+import com.paneedah.weaponlib.*;
 import org.lwjgl.opengl.GL11;
 
 public class AuxiliaryAttachments {
@@ -224,7 +221,7 @@ public class AuxiliaryAttachments {
     public static ItemAttachment<Weapon> ChainA;
     public static ItemAttachment<Weapon> ChainB;
 
-    public static void init(Object mod) {
+    public static void init(ModContext modContext) {
         
 /*
     	PanelUpper = new AttachmentBuilder<Weapon>()
@@ -233,7 +230,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinPanelUpper(), "ninthsin.png")
                 .withName("PanelUpper")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	PanelLower = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -241,7 +238,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinPanelLower(), "ninthsin.png")
                 .withName("PanelLower")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorUpper = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -249,7 +246,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorUpper(), "ninthsin.png")
                 .withName("RegulatorUpper")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorLower = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -257,7 +254,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorLower(), "ninthsin.png")
                 .withName("RegulatorLower")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorRotator = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA5)
@@ -265,7 +262,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorRotator(), "ninthsin.png")
                 .withName("RegulatorRotator")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorActionUpper = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA6)
@@ -273,7 +270,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorActionUpper(), "ninthsin.png")
                 .withName("RegulatorActionUpper")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorActionLower = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA7)
@@ -281,7 +278,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorActionLower(), "ninthsin.png")
                 .withName("RegulatorActionLower")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	RegulatorAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA8)
@@ -289,7 +286,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinRegulatorAction(), "ninthsin.png")
                 .withName("RegulatorAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	CyclerFront = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA9)
@@ -297,7 +294,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinCycleFront(), "ninthsin.png")
                 .withName("CyclerFront")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	CyclerBackLeft = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA10)
@@ -305,7 +302,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinCycleBackLeft(), "ninthsin.png")
                 .withName("CyclerBackLeft")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	CyclerBackRight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA11)
@@ -313,7 +310,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinCycleBackRight(), "ninthsin.png")
                 .withName("CyclerBackRight")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
     	
     	Cycler = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA12)
@@ -321,7 +318,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.NinthSinCycle(), "ninthsin.png")
                 .withName("Cycler")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 */
         ChainB = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -329,7 +326,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.ChainsawChainB(), "chainsaw.png")
                 .withName("ChainB")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ChainA = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -337,7 +334,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.ChainsawChainA(), "chainsaw.png")
                 .withName("ChainA")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Chain = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -345,7 +342,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.ChainsawChain(), "chainsaw.png")
                 .withName("Chain")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G95IronSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -354,7 +351,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.G95_rearsights(), "gun.png")
                 .withName("G95IronSights")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G95UprightIronSights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -363,7 +360,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.G95_upright_rearsights(), "gun.png")
                 .withName("G95UprightIronSights")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Origin12Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -371,7 +368,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.Origin12Action(), "origin12.png")
                 .withName("Origin12Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P90Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -379,7 +376,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.P90Action(), "p90.png")
                 .withName("P90Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1CarbineAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -387,7 +384,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M1CarbineAction(), "gun.png")
                 .withName("M1CarbineAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         G11Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -396,7 +393,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.G11Action(), "gun.png")
                 .withName("G11Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AUGAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -404,7 +401,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AUGaction(), "aug.png")
                 .withName("AUGAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAS21Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -416,7 +413,7 @@ public class AuxiliaryAttachments {
                 .withRenderablePart()
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAS21Barrel = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -426,7 +423,7 @@ public class AuxiliaryAttachments {
                 .withRenderablePart()
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MAS21Part = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -436,7 +433,7 @@ public class AuxiliaryAttachments {
                 .withRenderablePart()
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M32Main1B = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -445,7 +442,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.Suppressor(), "gun.png")
                 .withName("M32Main1B")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M134Barrels = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -453,21 +450,21 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M134Barrels(), "gun.png")
                 .withName("M134Barrels")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         BrowningAuto5Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.BrowningAuto5Action(), "gun.png").withName("BrowningAuto5Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1GarandAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.M1GarandAction(), "gun.png").withName("M1GarandAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1GarandMag = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -476,21 +473,21 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M1GarandMag2(), "M1GarandMag.png")
                 .withName("M1GarandMag")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M1897Pump = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.M1897Pump(), "m1897.png").withName("M1897pump")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Super90Pump = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.Super90Pump(), "gun.png").withName("Super90Pump")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
 //        P226Slide = new AttachmentBuilder<Weapon>()
 //                .withCategory(AttachmentCategory.EXTRA)
@@ -500,7 +497,7 @@ public class AuxiliaryAttachments {
 //                .withModel(new com.paneedah.mwc.models.P226frontsight(), "p226frontsight.png")
 //                .withName("P226Slide")
 //                .withRenderablePart().withTextureName("Dummy.png")
-//                .build(MWC.modContext);
+//                .build(modContext);
 
         PythonChamber = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -509,7 +506,7 @@ public class AuxiliaryAttachments {
                 .withName("PythonChamber")
                 .withPivotPoint(-0.11759999474287039F, -0.9064000131249434F, -0.8943999600172051F)
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RevolverSpeedLoader = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -518,7 +515,7 @@ public class AuxiliaryAttachments {
                 .withName("RevolverSpeedloader")
                 .withPivotPoint(-0.11759999474287039F, 0.07280001164674715F, 0.8548000601351243F)
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RevolverSpeedLoaderBullets = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -527,7 +524,7 @@ public class AuxiliaryAttachments {
                 .withName("RevolverSpeedloaderBullets")
                 .withPivotPoint(-0.11759999474287039F, -0.9064000131249434F, -0.8943999600172051F)
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MagnumChamber = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -536,35 +533,35 @@ public class AuxiliaryAttachments {
                 .withName("MagnumChamber")
                 .withPivotPoint(-0.11759999474287039F, -0.9064000131249434F, -0.8943999600172051F)
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         RhinoChamber = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new ChiappoRhinoChamber(), "chiapparhino.png").withName("RhinoChamber")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ACRAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.ACRAction(), "ACR.png")
                 .withModel(new com.paneedah.mwc.models.ACRAction2(), "gun.png")
                 .withName("ACRAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1014Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.M1014action(), "m1014.png")
                 .withName("M1014Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ShotgunInsertion = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.ShotgunInsertion(), "ShotgunInsertion.png")
                 .withName("ShotgunInsertion").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         SupernovaPump = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.SupernovaPump(), "supernova.png")
                 .withName("SupernovaPump").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ACRRails = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "acrrail.png")
@@ -573,56 +570,56 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AKRail4(), "acrrail.png")
                 .withModel(new com.paneedah.mwc.models.AKRail5(), "acrrail.png")
                 .withName("ACRRails").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         RPG7rocket = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.RPG7rocket(), "rpg7.png")
                 .withRenderablePart()
                 .withName("RPG7rocket")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M202rockets = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.M202Rockets(), "gun.png")
                 .withRenderablePart()
                 .withName("m202rockets")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         GLgrenade = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA6)
                 .withModel(new GL06Grenade(), "GL06.png")
                 .withRenderablePart()
                 .withName("GLgrenade")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M79grenade = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA6)
                 .withModel(new com.paneedah.mwc.models.M79grenade(), "gun.png")
                 .withRenderablePart()
                 .withName("M79grenade")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         GL06Cartridge = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.GL06Cartridge(), "GL06.png")
                 .withRenderablePart()
                 .withName("GL06Cartridge")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M79Cartridge = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.M79Cartridge(), "m79.png")
                 .withRenderablePart()
                 .withName("M79Cartridge")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M32Cartridge = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.M32Cartridge(), "gun.png")
                 .withRenderablePart()
                 .withName("M32Cartridge")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M41AMag = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -631,7 +628,7 @@ public class AuxiliaryAttachments {
                 .withName("M41AMag")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP43Edoublebarrel = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -640,7 +637,7 @@ public class AuxiliaryAttachments {
                 .withName("MP43Edoublebarrel")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         HS12Barrels = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -652,7 +649,7 @@ public class AuxiliaryAttachments {
                 .withName("HS12Barrels")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1873action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -661,7 +658,7 @@ public class AuxiliaryAttachments {
                 .withName("M1873action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         F2000Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -670,7 +667,7 @@ public class AuxiliaryAttachments {
                 .withName("F2000Action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         G36CAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -679,7 +676,7 @@ public class AuxiliaryAttachments {
                 .withName("G36CAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ARX160Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -688,7 +685,7 @@ public class AuxiliaryAttachments {
                 .withName("ARX160Action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1A1ThompsonAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -697,7 +694,7 @@ public class AuxiliaryAttachments {
                 .withName("M1A1ThompsonAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         KedrAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -706,7 +703,7 @@ public class AuxiliaryAttachments {
                 .withName("KedrAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         KedrStock = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -715,7 +712,7 @@ public class AuxiliaryAttachments {
                 .withName("KedrStock")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP7Grip = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -725,7 +722,7 @@ public class AuxiliaryAttachments {
                 .withPivotPoint(-0.12000000357627871F, -0.20000000596046452F, -1.6000000476837126F)
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1928ThompsonAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -734,7 +731,7 @@ public class AuxiliaryAttachments {
                 .withName("M1928ThompsonAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1A1Sight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -743,7 +740,7 @@ public class AuxiliaryAttachments {
                 .withName("M1A1ThompsonSight")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M1928Sight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -752,7 +749,7 @@ public class AuxiliaryAttachments {
                 .withName("M1928Sight")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         R870part = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -761,7 +758,7 @@ public class AuxiliaryAttachments {
                 .withName("R870part")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M82Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -770,7 +767,7 @@ public class AuxiliaryAttachments {
                 .withName("m82action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP40action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -779,7 +776,7 @@ public class AuxiliaryAttachments {
                 .withName("MP40action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP5boltaction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -789,7 +786,7 @@ public class AuxiliaryAttachments {
                 .withPivotPoint(-0.12000000357627871F, -1.1200000333786013F, -2.320000069141389F)
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         UMP45action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -799,7 +796,7 @@ public class AuxiliaryAttachments {
                 .withPivotPoint(-0.12000000357627871F, -1.1200000333786013F, -2.320000069141389F)
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP5action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -808,7 +805,7 @@ public class AuxiliaryAttachments {
                 .withName("MP5action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MP7action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -817,7 +814,7 @@ public class AuxiliaryAttachments {
                 .withName("MP7action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         G3Bolt = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -827,7 +824,7 @@ public class AuxiliaryAttachments {
                 .withPivotPoint(0.0F, -1.0800000321865084F, -4.120000122785571F)
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         G3Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -836,7 +833,7 @@ public class AuxiliaryAttachments {
                 .withName("G3Action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MG42Belt = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -845,7 +842,7 @@ public class AuxiliaryAttachments {
                 .withName("mg42belt")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MG42latch = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -854,7 +851,7 @@ public class AuxiliaryAttachments {
                 .withName("mg42latch")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MG34latch = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -863,7 +860,7 @@ public class AuxiliaryAttachments {
                 .withName("mg34latch")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M60Belt = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -872,7 +869,7 @@ public class AuxiliaryAttachments {
                 .withName("M60Belt")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         StonerHATCH = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -882,7 +879,7 @@ public class AuxiliaryAttachments {
                 .withName("StonerHATCH")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         StonerBELT = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -891,7 +888,7 @@ public class AuxiliaryAttachments {
                 .withName("StonerBELT")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         JohnsonACTION = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -900,7 +897,7 @@ public class AuxiliaryAttachments {
                 .withName("JohnsonLMGACTION")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         JohnsonRifleACTION = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -909,7 +906,7 @@ public class AuxiliaryAttachments {
                 .withName("JohnsonRifleAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         JohnsonRifleSight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -918,7 +915,7 @@ public class AuxiliaryAttachments {
                 .withName("JohnsonRifleSight")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         StripperClip = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -927,7 +924,7 @@ public class AuxiliaryAttachments {
                 .withName("StripperClip")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         StripperClipBullets = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -936,7 +933,7 @@ public class AuxiliaryAttachments {
                 .withName("StripperClipBullets")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         NTW20Barrel = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -945,7 +942,7 @@ public class AuxiliaryAttachments {
                 .withName("NTW20Barrel")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         NTW20Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -954,7 +951,7 @@ public class AuxiliaryAttachments {
                 .withName("NTW20Action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M60Hatch = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -963,7 +960,7 @@ public class AuxiliaryAttachments {
                 .withName("M60Hatch")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M249Belt = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -972,7 +969,7 @@ public class AuxiliaryAttachments {
                 .withName("M249Belt")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M249Hatch = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -984,7 +981,7 @@ public class AuxiliaryAttachments {
                 .withName("M249Hatch")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M249Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -993,7 +990,7 @@ public class AuxiliaryAttachments {
                 .withName("M249Action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MG42action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1002,7 +999,7 @@ public class AuxiliaryAttachments {
                 .withName("mg42action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ScarAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1011,7 +1008,7 @@ public class AuxiliaryAttachments {
                 .withName("ScarAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ScarHAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1020,7 +1017,7 @@ public class AuxiliaryAttachments {
                 .withName("ScarHAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         Mk14EBRaction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1029,7 +1026,7 @@ public class AuxiliaryAttachments {
                 .withName("Mk14EBRaction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         Mk14EBRsight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1038,7 +1035,7 @@ public class AuxiliaryAttachments {
                 .withName("Mk14EBRsight")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M14DMRRail = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1047,7 +1044,7 @@ public class AuxiliaryAttachments {
                 .withName("M14DMRRail")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         STG44action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1056,7 +1053,7 @@ public class AuxiliaryAttachments {
                 .withName("STG44action")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         STG44actionCover = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1065,7 +1062,7 @@ public class AuxiliaryAttachments {
                 .withName("STG44actioncover")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         G43GewehrAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1074,7 +1071,7 @@ public class AuxiliaryAttachments {
                 .withName("G43GewehrAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         SpringfieldRearSight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1082,7 +1079,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.SpringfieldRearSight(), "gun.png")
                 .withName("SpringfieldRearSight")
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         SpringfieldAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA7)
@@ -1091,7 +1088,7 @@ public class AuxiliaryAttachments {
                 .withName("SpringfieldAction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         Kar98Kaction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA7)
@@ -1100,7 +1097,7 @@ public class AuxiliaryAttachments {
                 .withName("Kar98Kaction")
                 .withRenderablePart()
 
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         VP70slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1110,7 +1107,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.GlockRearSight(), "glockrearsight")
                 .withName("VP70slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         APSslide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1120,7 +1117,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.APSrearsight(), "gun")
                 .withName("APSslide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         APShammer = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1128,7 +1125,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.APShammer(), "APS.png")
                 .withName("APShammer")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         USP45hammer = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1136,7 +1133,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.USP45Hammer(), "usp45.png")
                 .withName("USP45hammer")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P226hammer = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1144,7 +1141,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.P226Hammer(), "p226.png")
                 .withName("P226hammer")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M9A1hammer = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1152,7 +1149,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M9hammer(), "m9a1.png")
                 .withName("M9A1hammer")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         MP443hammer = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1160,7 +1157,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.MP443Hammer(), "mp443.png")
                 .withName("MP443hammer")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M712action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1168,7 +1165,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M712action(), "m712.png")
                 .withName("M712action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M45A1slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1178,7 +1175,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M1911rearsight(), "m1911rearsight")
                 .withName("M45A1slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M17_Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1188,7 +1185,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M9A1rearsight(), "M9A1rearsight")
                 .withName("m17_slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Makarov_Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1198,7 +1195,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.makarovfrontsight(), "gun.png")
                 .withName("Makarov_Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P12_Slide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1208,7 +1205,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.P2000rearsight(), "m1911frontsight.png")
                 .withName("P12_Slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         BrowningHiPowerSlide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1218,7 +1215,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.makarovrearsight(), "gun")
                 .withName("BrowningHiPowerSlide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         VSSVintorezAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1226,7 +1223,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.VSSVintorezAction(), "vssvintorez.png")
                 .withName("VSSVintorezAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AKaction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1234,7 +1231,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AK47Action(), "ak47.png")
                 .withName("AKaction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DragunovAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1242,7 +1239,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.DragunovAction(), "dragunov.png")
                 .withName("DragunovAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Malyukaction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1250,7 +1247,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.MalyukAction(), "malyuk.png")
                 .withName("Malyukaction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK15action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1258,7 +1255,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AK15Action(), "ak15.png")
                 .withName("AK15action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KBP9A91action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1266,7 +1263,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.KBP9A91Action(), "KBP9A91.png")
                 .withName("KBP9A91action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALActionLever = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1274,7 +1271,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.FNFALActionLever(), "FNFAL.png")
                 .withName("FNFALActionLever")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FNFALAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1282,7 +1279,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.FNFALAction(), "FNFAL.png")
                 .withName("FNFALAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         FamasF1Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1290,7 +1287,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.FamasF1Action(), "famasf1.png")
                 .withName("FamasF1Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AK12action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1298,14 +1295,14 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AK12action(), "ak12kal.png")
                 .withName("AK12action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Saiga12action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.Saiga12action(), "gun.png").withName("Saiga12action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Saiga12sights = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1314,7 +1311,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.makarovfrontsight(), "gun.png")
                 .withName("Saiga12sights")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AS50Action = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1322,7 +1319,7 @@ public class AuxiliaryAttachments {
                 .withModel(new AS50action(), "as50.png")
                 .withName("AS50Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Albert01Rslide = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1332,7 +1329,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M9A1rearsight(), "M9A1rearsight")
                 .withName("albert01R_slide")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UziAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1340,7 +1337,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.UziAction(), "gun.png")
                 .withName("UziAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UziRelease = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1348,7 +1345,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.UziRelease(), "gun.png")
                 .withName("UziRelease")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         UziIronSight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1357,7 +1354,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.UziRearSight(), "gun.png")
                 .withName("UziIronSight")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         P10frontsight = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1367,7 +1364,7 @@ public class AuxiliaryAttachments {
 //                .withModel(new com.paneedah.mwc.models.M9A1rearsight(), "M9A1rearsight")
                 .withName("P10frontsight")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M40A6BoltAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1375,7 +1372,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.GunwerksHAMRboltaction(), "gunwerkshamr")
                 .withName("M40A6BoltAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M40A6BoltActionPrime = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1383,7 +1380,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.GunwerksHAMRboltactionPrime(), "gunwerkshamr")
                 .withName("M40A6BoltActionPrime")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SSG08BoltAction1 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1391,7 +1388,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.SSG08BoltAction1(), "SSG08_2")
                 .withName("SSG08BoltAction1")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SSG08BoltAction2 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1399,7 +1396,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.SSG08BoltAction2(), "SSG08")
                 .withName("SSG08")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington700BoltAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1407,7 +1404,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.R700action(), "remington700")
                 .withName("Remington700BoltAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Remington700BoltActionMain = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1415,7 +1412,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.R700actionMain(), "remington700")
                 .withName("Remington700BoltActionMain")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         SV98BoltAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1423,21 +1420,21 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.SV98Action(), "sv98")
                 .withName("SV98BoltAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         L115Bolt1 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.L96Action(), "L96Action.png").withName("L96Action")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         L115Bolt2 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.L115Bolt2(), "gun.png").withName("LP115Bolt2")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1BoltAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1445,7 +1442,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.DSR1BoltAction(), "dsr1.png")
                 .withName("DSR1BoltAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         DSR1BoltActionMain = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1453,7 +1450,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.DSR1BoltActionMain(), "dsr1.png")
                 .withName("DSR1BoltActionMain")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         InterventionBoltAction = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1461,14 +1458,14 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.InterventionBoltAction(), "intervention.png")
                 .withName("InterventionBoltAction")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         L115Mag = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
                 // .withCreativeTab(MWC.gunsTab)
                 .withModel(new com.paneedah.mwc.models.L115Mag(), "gun.png").withName("L115Mag")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         M500A2pump = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1476,7 +1473,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.M500A2pump(), "gun")
                 .withName("M500A2pump")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         HESCSpump = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1484,7 +1481,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.HEShotgunPump(), "spas12")
                 .withName("HESCSpump")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KS23pump = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1492,7 +1489,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.KS23pump(), "ks23")
                 .withName("KS23pump")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KragAction1 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1500,7 +1497,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.KragJorgensenAction1(), "KragJorgensen")
                 .withName("KragAction1")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KragAction2 = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA3)
@@ -1508,7 +1505,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.KragJorgensenAction2(), "KragJorgensen")
                 .withName("KragAction2")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         KragChamber = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1516,7 +1513,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.KragJorgensenChamber(), "KragJorgensen")
                 .withName("KragChamber")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ShotgunShell = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1524,7 +1521,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.Shotgun12Gauge(), "shotgun12gauge")
                 .withName("ShotgunShell")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         ShotgunShellDouble = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA2)
@@ -1533,7 +1530,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.Shotgun12Gauge2(), "shotgun12gauge")
                 .withName("ShotgunShellDouble")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Shotgun4Gauge = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1541,7 +1538,7 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.Shotgun12Gauge(), "Shotgun4Gauge")
                 .withName("Shotgun4Gauge")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Bullet = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1551,7 +1548,7 @@ public class AuxiliaryAttachments {
                 .withRenderablePart()
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         BulletSmall = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA)
@@ -1561,7 +1558,7 @@ public class AuxiliaryAttachments {
                 .withRenderablePart()
 
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         LaserProjectile = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA4)
@@ -1569,72 +1566,72 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.LaserProjectile(), "Laser")
                 .withName("LaserProjectile")
                 .withRenderablePart().withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         AR15Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.AR15Action(), "ar15action.png")
                 .withName("AR15Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M4EjectorAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA)
                 .withModel(new com.paneedah.mwc.models.M4A1Action(), "m4a1.png")
                 .withName("M4EjectorAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         SIG556Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA)
                 .withModel(new com.paneedah.mwc.models.SIG556Action(), "sig556.png")
                 .withName("SIG556Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         SIGMCXAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA)
                 .withModel(new com.paneedah.mwc.models.SIGMCXAction(), "sigMCx.png")
                 .withName("SIGMCXAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M110EjectorAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA)
                 .withModel(new com.paneedah.mwc.models.M110Action(), "m110.png")
                 .withName("M110EjectorAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         BeowulfAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA)
                 .withModel(new com.paneedah.mwc.models.Beowulf50CalAction(), "beowulf50cal.png")
                 .withName("BeowulfAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         S710TricunActionPully = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.S710TricunActionPully(), "s710tricun.png")
                 .withName("S710TricunActionPully").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         S710TricunActionEjector = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.S710TricunActionEjector(), "s710tricun.png")
                 .withName("S710TricunActionEjector").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         K2C1Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.K2C1Action(), "k2c1.png")
                 .withName("K2C1Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         ScorpionAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.ScorpionEVO3A1Action(), "ScorpionEVO3A1.png")
                 .withName("ScorpionAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         APC9Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.APC9Action(), "gun.png")
                 .withName("APC9Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         BrenAction = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.CZ805BrenAction(), "cz805bren.png")
                 .withName("BrenAction").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M110Action = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA2)
                 .withModel(new com.paneedah.mwc.models.AR15Action(), "M110action.png")
                 .withName("M110Action").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         AR15Iron = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.SCOPE)
                 .withCreativeTab(MWC.ATTACHMENTS_TAB)
@@ -1674,7 +1671,7 @@ public class AuxiliaryAttachments {
                     }
                 })
                 .withName("AR15Iron").withTextureName("Dummy.png")
-                .build(MWC.modContext);
+                .build(modContext);
 
         Extra = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.EXTRA6)
@@ -1687,7 +1684,7 @@ public class AuxiliaryAttachments {
                 .withModel(new FALIron(), "gun.png").withModel(new M14Iron(), "gun.png")
                 .withModel(new MP5Iron(), "gun.png")
                 .withName("Extra")
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M4Rail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "akrail.png")
@@ -1696,27 +1693,27 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AKRail4(), "akrail.png")
                 .withModel(new com.paneedah.mwc.models.AKRail5(), "akrail.png")
                 .withName("M4Rail").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M4AsiimovRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "m4asiimovrail.png")
                 .withName("M4AsiimovRail").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         MagnumRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "magnumrail.png")
                 .withName("MagnumRail").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         RailAlt = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.RailAlt(), "gun.png")
                 .withName("RailAlt").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         AACRail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "aacrail_main.png")
                 .withName("AACRail").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         M110Rail = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKRail(), "M110.png")
@@ -1725,17 +1722,17 @@ public class AuxiliaryAttachments {
                 .withModel(new com.paneedah.mwc.models.AKRail4(), "M110.png")
                 .withModel(new com.paneedah.mwc.models.AKRail5(), "M110.png")
                 .withName("M110Rail").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         AKpart = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA5)
                 .withModel(new com.paneedah.mwc.models.AKpart(), "gun")
                 .withName("AKpart").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
 
         AKMuzzle = new AttachmentBuilder<Weapon>().withCategory(AttachmentCategory.EXTRA3)
                 .withModel(new com.paneedah.mwc.models.Suppressor(), "gun")
                 .withName("AKmuzzle").withRenderablePart()
-                .withTextureName("Dummy.png").build(MWC.modContext);
+                .withTextureName("Dummy.png").build(modContext);
     }
 
 }

--- a/src/main/java/com/paneedah/mwc/weapons/Bullets.java
+++ b/src/main/java/com/paneedah/mwc/weapons/Bullets.java
@@ -3,6 +3,7 @@ package com.paneedah.mwc.weapons;
 import com.paneedah.mwc.MWC;
 import com.paneedah.mwc.init.MWCItems;
 import com.paneedah.weaponlib.ItemBullet;
+import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.crafting.CraftingComplexity;
 import net.minecraft.init.Items;
 import org.lwjgl.opengl.GL11;
@@ -52,7 +53,7 @@ public class Bullets {
     public static ItemBullet EnergyCase;
     public static ItemBullet PlasmaCapsule;
 
-    public static void init(Object mod) {
+    public static void init(ModContext modContext) {
         Grenade40mm = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("Grenade40mm").withMaxStackSize(16)
                 .withModel(new com.paneedah.mwc.models.GL06Grenade(), "GL06.png")
@@ -73,7 +74,7 @@ public class Bullets {
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(2F, 2F, 2f);
                 }).withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         M202Rocket = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("m202rocket").withMaxStackSize(4)
@@ -95,7 +96,7 @@ public class Bullets {
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(0.4F, 0.4F, 0.4f);
                 }).withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         RPGRocket = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("rpg7_rocket").withMaxStackSize(2)
@@ -117,7 +118,7 @@ public class Bullets {
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(0.4F, 0.4F, 0.4f);
                 }).withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         EnergyCase = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("EnergyCase")
@@ -139,7 +140,7 @@ public class Bullets {
                     GL11.glRotatef(2F, 1f, 0f, 0f);
                     GL11.glRotatef(20F, 0f, 0f, 1f);
                     GL11.glScaled(1.4F, 1.4F, 1.4f);
-                }).withTextureName("Dummy.png").build(MWC.modContext, ItemBullet.class);
+                }).withTextureName("Dummy.png").build(modContext, ItemBullet.class);
 
         PlasmaCapsule = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("PlasmaCapsule")
@@ -162,7 +163,7 @@ public class Bullets {
                     GL11.glRotatef(-15F, 0f, 0f, 1f);
                     GL11.glScaled(1F, 1F, 1f);
                 })
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemBullet.class);
+                .withTextureName("Dummy.png").build(modContext, ItemBullet.class);
 
         Bullet3006Springfield = new ItemBullet.Builder()
 
@@ -186,7 +187,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.6F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet8x58 = new ItemBullet.Builder()
 
@@ -210,7 +211,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.4F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet792x33Kurz = new ItemBullet.Builder()
 
@@ -234,7 +235,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.35F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet50BMG = new ItemBullet.Builder()
 
@@ -258,7 +259,7 @@ public class Bullets {
                     GL11.glScaled(1.7F, 1.6F, 1.7f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet20x82mm = new ItemBullet.Builder()
 
@@ -282,7 +283,7 @@ public class Bullets {
                     GL11.glScaled(1.7F, 1.6F, 1.7f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet408CT = new ItemBullet.Builder()
 
@@ -306,7 +307,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.6F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet308Winchester = new ItemBullet.Builder()
 
@@ -330,7 +331,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.5F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet277 = new ItemBullet.Builder()
 
@@ -354,7 +355,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.5F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet792x57 = new ItemBullet.Builder()
 
@@ -378,7 +379,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.6F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet762x54 = new ItemBullet.Builder()
 
@@ -402,7 +403,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.6F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet762x51 = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -425,7 +426,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.6F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Shotgun12Guage = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("Shotgun12Gauge")
@@ -445,7 +446,7 @@ public class Bullets {
                     GL11.glRotatef(2F, 1f, 0f, 0f);
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(1.4F, 1.4F, 1.4f);
-                }).withTextureName("Dummy.png").build(MWC.modContext, ItemBullet.class);
+                }).withTextureName("Dummy.png").build(modContext, ItemBullet.class);
 
         Shotgun4G = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB).withName("Shotgun4G")
@@ -465,7 +466,7 @@ public class Bullets {
                     GL11.glRotatef(2F, 1f, 0f, 0f);
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(1.4F, 1.4F, 1.4f);
-                }).withTextureName("Dummy.png").build(MWC.modContext, ItemBullet.class);
+                }).withTextureName("Dummy.png").build(modContext, ItemBullet.class);
 
         Bullet762x35 = new ItemBullet.Builder()
 
@@ -489,7 +490,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.4F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet765x21 = new ItemBullet.Builder()
 
@@ -513,7 +514,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.2F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet762x39 = new ItemBullet.Builder()
 
@@ -537,7 +538,7 @@ public class Bullets {
                     GL11.glScaled(1.6F, 1.5F, 1.6f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet556x45 = new ItemBullet.Builder()
 
@@ -561,7 +562,7 @@ public class Bullets {
                     GL11.glScaled(1.4F, 1.55F, 1.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet65 = new ItemBullet.Builder()
 
@@ -585,7 +586,7 @@ public class Bullets {
                     GL11.glScaled(1.4F, 1.55F, 1.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet545x39 = new ItemBullet.Builder()
 
@@ -609,7 +610,7 @@ public class Bullets {
                     GL11.glScaled(1.5F, 1.55F, 1.5f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet4570 = new ItemBullet.Builder()
 
@@ -633,7 +634,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 3F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet4440 = new ItemBullet.Builder()
 
@@ -657,7 +658,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet45ACP = new ItemBullet.Builder()
 
@@ -681,7 +682,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet357 = new ItemBullet.Builder()
 
@@ -705,7 +706,7 @@ public class Bullets {
                     GL11.glScaled(2.0F, 2.8F, 2.0f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet44 = new ItemBullet.Builder()
 
@@ -729,7 +730,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 3F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet40SW = new ItemBullet.Builder()
 
@@ -753,7 +754,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet50AE = new ItemBullet.Builder()
 
@@ -777,7 +778,7 @@ public class Bullets {
                     GL11.glScaled(2.8F, 3F, 2.8f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet50Beowulf = new ItemBullet.Builder()
 
@@ -801,7 +802,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 3F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet500 = new ItemBullet.Builder()
 
@@ -825,7 +826,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 3F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet380ACP = new ItemBullet.Builder()
 
@@ -849,7 +850,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet763x25 = new ItemBullet.Builder()
 
@@ -872,7 +873,7 @@ public class Bullets {
                     GL11.glRotatef(0F, 0f, 0f, 1f);
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 }).withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet9x39mm = new ItemBullet.Builder()
 
@@ -896,7 +897,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet9x19mm = new ItemBullet.Builder()
 
@@ -920,7 +921,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet9x18mm = new ItemBullet.Builder()
 
@@ -944,7 +945,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.4F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet57x28mm = new ItemBullet.Builder()
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -967,7 +968,7 @@ public class Bullets {
                     GL11.glScaled(1.3F, 1.2F, 1.3f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet46x30mm = new ItemBullet.Builder()
 
@@ -991,7 +992,7 @@ public class Bullets {
                     GL11.glScaled(1.3F, 1.2F, 1.3f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet10mm = new ItemBullet.Builder()
 
@@ -1015,7 +1016,7 @@ public class Bullets {
                     GL11.glScaled(2.4F, 2.8F, 2.4f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
 
         Bullet473x33mm = new ItemBullet.Builder()
 
@@ -1039,7 +1040,7 @@ public class Bullets {
                     GL11.glScaled(1.7F, 2F, 1.7f);
                 })
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemBullet.class);
+                .build(modContext, ItemBullet.class);
     }
 
 }

--- a/src/main/java/com/paneedah/mwc/weapons/Guns.java
+++ b/src/main/java/com/paneedah/mwc/weapons/Guns.java
@@ -164,7 +164,7 @@ public class Guns {
 
     public static Item Chainsaw;
 
-    public static void init(Object mod, CommonProxy proxy) {
+    public static void init(CommonProxy proxy) {
         // Try not to change the order of the guns to ensure stable recipes
         //AR2
         M4A1 = new M4A1Factory().createGun(proxy);

--- a/src/main/java/com/paneedah/mwc/weapons/Magazines.java
+++ b/src/main/java/com/paneedah/mwc/weapons/Magazines.java
@@ -5,6 +5,7 @@ import com.paneedah.mwc.init.MWCItems;
 import com.paneedah.mwc.models.UMP45mag;
 import com.paneedah.mwc.models.UMP9Mag;
 import com.paneedah.weaponlib.ItemMagazine;
+import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.crafting.CraftingComplexity;
 import org.lwjgl.opengl.GL11;
 
@@ -128,7 +129,7 @@ public class Magazines {
     public static ItemMagazine FuelCell;
     public static ItemMagazine NinthSinMag;
 
-    public static void init(Object mod) {
+    public static void init(ModContext modContext) {
 
         Magazines.FuelCell = new ItemMagazine.Builder().withCapacity(1000)
                 .withName("FuelCell")
@@ -155,7 +156,7 @@ public class Magazines {
 //                .withCrafting(CraftingComplexity.MEDIUM,
 //                          MwItems.steelIngot,
 //                          MwItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 /*
         Magazines.NinthSinMag = new ItemMagazine.Builder()
         		.withCapacity(100)
@@ -184,7 +185,7 @@ public class Magazines {
 //                .withCrafting(CraftingComplexity.MEDIUM,
 //                          MwItems.steelIngot,
 //                          MwItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 */
         Magazines.BrenMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -214,7 +215,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.JohnsonMAG = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -243,7 +244,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.VectorMag = new ItemMagazine.Builder()
                 .withCapacity(25)
@@ -271,7 +272,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(5)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.VectorDrumMag = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -299,7 +300,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(5)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M4A1Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -330,7 +331,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.NGSWRMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -357,7 +358,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.FamasF1Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -385,7 +386,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.BeowulfMag = new ItemMagazine.Builder()
                 .withCapacity(13)
@@ -414,7 +415,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AUG9mmMag = new ItemMagazine.Builder().withCapacity(30).withCompatibleBullet(Bullets.Bullet9x19mm).withName("AUG9mmMag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -440,7 +441,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.S710TricunMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -469,7 +470,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M134Mag = new ItemMagazine.Builder().withCapacity(1000).withCompatibleBullet(Bullets.Bullet762x51).withName("M134Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -495,7 +496,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M60Mag = new ItemMagazine.Builder().withCapacity(100).withCompatibleBullet(Bullets.Bullet762x51).withName("M60Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -521,7 +522,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M249Mag = new ItemMagazine.Builder()
                 .withCapacity(100)
@@ -552,7 +553,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.StonerMag = new ItemMagazine.Builder().withCapacity(100).withCompatibleBullet(Bullets.Bullet556x45).withName("StonerMag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -578,7 +579,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.HoneyBadgerMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -606,7 +607,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M38Mag = new ItemMagazine.Builder()
 
@@ -639,7 +640,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SOCOM_Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -669,7 +670,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.HK417Mag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -695,7 +696,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.C8Mag = new ItemMagazine.Builder().withCapacity(30).withCompatibleBullet(Bullets.Bullet556x45).withName("C8Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -719,7 +720,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Stanag50 = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -750,7 +751,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Stanag60 = new ItemMagazine.Builder()
                 .withCapacity(60)
@@ -781,7 +782,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Stanag100 = new ItemMagazine.Builder()
                 .withCapacity(100)
@@ -811,7 +812,7 @@ public class Magazines {
                     GL11.glScaled(1.2F, 1.2F, 1.2f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.G36CMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -839,7 +840,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK101Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -867,7 +868,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK74Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -895,7 +896,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK74Mag60 = new ItemMagazine.Builder()
                 .withCapacity(60)
@@ -923,7 +924,7 @@ public class Magazines {
                     GL11.glScaled(0.6F, 0.6F, 0.6f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK60Mag = new ItemMagazine.Builder()
                 .withCapacity(60)
@@ -951,7 +952,7 @@ public class Magazines {
                     GL11.glScaled(0.6F, 0.6F, 0.6f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK15Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -979,7 +980,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK12Mag545x39 = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -1007,7 +1008,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK75Mag545x39 = new ItemMagazine.Builder()
                 .withCapacity(75)
@@ -1034,7 +1035,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK12Mag = new ItemMagazine.Builder()
                 .withCapacity(31)
@@ -1061,7 +1062,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK47PMAGTan = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -1089,7 +1090,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK47Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -1117,7 +1118,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK50Mag = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -1145,7 +1146,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK75Mag = new ItemMagazine.Builder()
                 .withCapacity(75)
@@ -1172,7 +1173,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AK100Mag = new ItemMagazine.Builder()
                 .withCapacity(100)
@@ -1200,7 +1201,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.DragunovMag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -1229,7 +1230,7 @@ public class Magazines {
                 })
                 .withMaxStackSize(6)
                 .withTextureName("Dummy.png")
-                .build(MWC.modContext, ItemMagazine.class);
+                .build(modContext, ItemMagazine.class);
 
         Magazines.SaigaMag = new ItemMagazine.Builder().withCapacity(5).withCompatibleBullet(Bullets.Shotgun12Guage).withName("SaigaMag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1255,7 +1256,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Origin12Mag = new ItemMagazine.Builder()
                 .withCapacity(5)
@@ -1282,7 +1283,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Origin12DrumMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -1309,7 +1310,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M9A1Mag = new ItemMagazine.Builder()
                 .withCapacity(15)
@@ -1337,7 +1338,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.FiveSevenMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -1364,7 +1365,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SamuraiEdgeMag = new ItemMagazine.Builder().withCapacity(15).withCompatibleBullet(Bullets.Bullet40SW)
                 .withName("SamuraiEdgeMag")
@@ -1388,7 +1389,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SCCYCPX2Mag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -1416,7 +1417,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SCCYCPX2MagExt = new ItemMagazine.Builder()
                 .withCapacity(15)
@@ -1444,7 +1445,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.DesertEagleMag = new ItemMagazine.Builder()
                 .withCapacity(7)
@@ -1475,7 +1476,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M9Mag30 = new ItemMagazine.Builder().withCapacity(30).withCompatibleBullet(Bullets.Bullet9x19mm).withName("M9Mag30")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1498,7 +1499,7 @@ public class Magazines {
                     GL11.glScaled(0.75F, 0.75F, 0.75f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M9DrumMag = new ItemMagazine.Builder().withCapacity(65).withCompatibleBullet(Bullets.Bullet9x19mm).withName("M9DrumMag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1521,7 +1522,7 @@ public class Magazines {
                     GL11.glScaled(0.75F, 0.75F, 0.75f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MP443Mag = new ItemMagazine.Builder()
                 .withCapacity(18)
@@ -1548,7 +1549,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M45A1Mag = new ItemMagazine.Builder().withCapacity(7).withCompatibleBullet(Bullets.Bullet45ACP).withName("M45A1Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1574,7 +1575,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M1911_44Mag = new ItemMagazine.Builder().withCapacity(7).withCompatibleBullet(Bullets.Bullet44).withName("M1911_44Mag")
                 .withRequiredAttachments(Attachments.M191144MagBody)
@@ -1601,7 +1602,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M45A1Mag14 = new ItemMagazine.Builder().withCapacity(14).withCompatibleBullet(Bullets.Bullet45ACP).withName("M45A1Mag14")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1627,7 +1628,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
 
         Magazines.M17Mag = new ItemMagazine.Builder()
@@ -1654,7 +1655,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MakarovMag = new ItemMagazine.Builder().withCapacity(8)
                 .withCompatibleBullet(Bullets.Bullet9x18mm)
@@ -1679,7 +1680,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.USP45Mag = new ItemMagazine.Builder().withCapacity(8).withCompatibleBullet(Bullets.Bullet45ACP).withName("USP45Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1701,7 +1702,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.HiPowerMag = new ItemMagazine.Builder().withCapacity(13).withCompatibleBullet(Bullets.Bullet9x19mm).withName("HiPowerMag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1727,7 +1728,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.FrommerStopMag = new ItemMagazine.Builder().withCapacity(8).withCompatibleBullet(Bullets.Bullet380ACP).withName("FrommerStopMag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1753,7 +1754,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.APSMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -1780,7 +1781,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.GlockMag13 = new ItemMagazine.Builder().withCapacity(13).withCompatibleBullet(Bullets.Bullet9x19mm).withName("GlockMag13")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1803,7 +1804,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Glock18CMag = new ItemMagazine.Builder().withCapacity(20).withCompatibleBullet(Bullets.Bullet9x19mm).withName("Glock18Cmag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1826,7 +1827,7 @@ public class Magazines {
                     GL11.glScaled(0.6F, 0.6F, 0.6f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.GlockMag50 = new ItemMagazine.Builder().withCapacity(50).withCompatibleBullet(Bullets.Bullet9x19mm).withName("GlockMag50")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1849,7 +1850,7 @@ public class Magazines {
                     GL11.glScaled(0.75F, 0.75F, 0.75f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.AS50Mag = new ItemMagazine.Builder().withCapacity(10).withCompatibleBullet(Bullets.Bullet50BMG).withName("AS50Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1875,7 +1876,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M82Mag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -1903,7 +1904,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.NTW20Mag = new ItemMagazine.Builder().withCapacity(3).withCompatibleBullet(Bullets.Bullet20x82mm).withName("NTW20Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1929,7 +1930,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.KBP9A91Mag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -1956,7 +1957,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.KedrMag = new ItemMagazine.Builder().withCapacity(20).withCompatibleBullet(Bullets.Bullet9x19mm).withName("KedrMag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -1979,7 +1980,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.L96A1Mag = new ItemMagazine.Builder().withCapacity(10).withCompatibleBullet(Bullets.Bullet762x54).withName("L96A1Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2005,7 +2006,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.DSR1Mag = new ItemMagazine.Builder()
                 .withCapacity(5)
@@ -2035,7 +2036,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.DSR1MagExt = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -2065,7 +2066,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.InterventionMag = new ItemMagazine.Builder()
                 .withCapacity(7)
@@ -2094,7 +2095,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M40A6Mag = new ItemMagazine.Builder()
                 .withCapacity(7)
@@ -2124,7 +2125,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.R700Mag = new ItemMagazine.Builder().withCapacity(5).withCompatibleBullet(Bullets.Bullet762x54).withName("R700Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2150,7 +2151,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.R700Mag10rnd = new ItemMagazine.Builder().withCapacity(10).withCompatibleBullet(Bullets.Bullet762x54).withName("R700Mag10rnd")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2176,7 +2177,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SSG08Mag = new ItemMagazine.Builder()
                 .withCapacity(8)
@@ -2205,7 +2206,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M110Mag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -2231,7 +2232,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Z10Mag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -2258,7 +2259,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M1928Mag = new ItemMagazine.Builder().withCapacity(50).withCompatibleBullet(Bullets.Bullet45ACP).withName("M1928Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2284,7 +2285,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M1A1Mag = new ItemMagazine.Builder().withCapacity(30).withCompatibleBullet(Bullets.Bullet45ACP)
                 .withName("M1A1Mag")
@@ -2311,7 +2312,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M712Mag = new ItemMagazine.Builder().withCapacity(20).withCompatibleBullet(Bullets.Bullet763x25).withName("M712mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2337,7 +2338,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MG42Mag = new ItemMagazine.Builder().withCapacity(50).withCompatibleBullet(Bullets.Bullet792x57).withName("MG42Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2363,7 +2364,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.DP28Mag = new ItemMagazine.Builder().withCapacity(47).withCompatibleBullet(Bullets.Bullet762x54).withName("DP28Mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2389,7 +2390,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M1CarbineMag = new ItemMagazine.Builder()
                 .withCapacity(15)
@@ -2419,7 +2420,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.FNFALMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -2447,7 +2448,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.G3Mag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -2475,7 +2476,7 @@ public class Magazines {
                     GL11.glScaled(0.8F, 0.8F, 0.8f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Mk14EBRMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -2503,7 +2504,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.M14Drum50 = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -2531,7 +2532,7 @@ public class Magazines {
                     GL11.glScaled(1.2F, 1.2F, 1.2f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MP40Mag = new ItemMagazine.Builder().withCapacity(32).withCompatibleBullet(Bullets.Bullet9x19mm).withName("MP40Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -2557,7 +2558,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MP5A5Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -2585,7 +2586,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.HK50Drum = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -2613,7 +2614,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MP7Mag = new ItemMagazine.Builder()
                 .withCapacity(40)
@@ -2641,7 +2642,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MP7Mag20 = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -2669,7 +2670,7 @@ public class Magazines {
                     GL11.glScaled(0.9F, 0.9F, 0.9f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.UMP45Mag = new ItemMagazine.Builder()
                 .withCapacity(25)
@@ -2697,7 +2698,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.UMP9Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -2725,7 +2726,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MPXMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -2753,7 +2754,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.APC9Mag = new ItemMagazine.Builder().withCapacity(30)
                 .withCompatibleBullet(Bullets.Bullet9x19mm)
@@ -2781,7 +2782,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.ScorpionMag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -2809,7 +2810,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.P90Mag = new ItemMagazine.Builder()
                 .withCapacity(50)
@@ -2837,7 +2838,7 @@ public class Magazines {
                     GL11.glScaled(0.5F, 0.5F, 0.5f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.P90TerminatorMag = new ItemMagazine.Builder().withCapacity(65).withCompatibleBullet(Bullets.Bullet46x30mm)
                 .withName("P90TerminatorMag")
@@ -2864,7 +2865,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.MAC10Mag = new ItemMagazine.Builder()
                 .withCapacity(30)
@@ -2890,7 +2891,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.G11Mag = new ItemMagazine.Builder().withCapacity(50)
                 .withCompatibleBullet(Bullets.Bullet473x33mm)
@@ -2919,7 +2920,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.ScarHMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -2947,7 +2948,7 @@ public class Magazines {
                     GL11.glScaled(1.0F, 1.0F, 1.0f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Scar40Mag = new ItemMagazine.Builder()
                 .withCapacity(40)
@@ -2975,7 +2976,7 @@ public class Magazines {
                     GL11.glScaled(1.1F, 1.1F, 1.1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.Scar60Mag = new ItemMagazine.Builder()
                 .withCapacity(60)
@@ -3003,7 +3004,7 @@ public class Magazines {
                     GL11.glScaled(1F, 1F, 1f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.VSSVintorezMag = new ItemMagazine.Builder()
                 .withCapacity(10)
@@ -3031,7 +3032,7 @@ public class Magazines {
                     GL11.glScaled(0.75F, 0.75F, 0.75f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.ASValMag = new ItemMagazine.Builder()
                 .withCapacity(20)
@@ -3059,7 +3060,7 @@ public class Magazines {
                     GL11.glScaled(0.75F, 0.75F, 0.75f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.STG44Mag = new ItemMagazine.Builder().withCapacity(30).withCompatibleBullet(Bullets.Bullet792x33Kurz).withName("STG44Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -3085,7 +3086,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.G43GewehrMag = new ItemMagazine.Builder().withCapacity(10).withCompatibleBullet(Bullets.Bullet792x57).withName("g43_gewehr_mag")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -3111,7 +3112,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.SV98Mag = new ItemMagazine.Builder().withCapacity(10).withCompatibleBullet(Bullets.Bullet762x54).withName("SV98Mag_2")
                 .withCreativeTab(MWC.AMMUNITION_AND_MAGAZINES_TAB)
@@ -3137,7 +3138,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.UziMag = new ItemMagazine.Builder()
                 .withCapacity(32)
@@ -3168,7 +3169,7 @@ public class Magazines {
                 .withCrafting(CraftingComplexity.MEDIUM,
                         MWCItems.steelIngot,
                         MWCItems.gunmetalIngot)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
         Magazines.VP70Mag = new ItemMagazine.Builder()
                 .withCapacity(18)
@@ -3195,7 +3196,7 @@ public class Magazines {
                     GL11.glScaled(0.7F, 0.7F, 0.7f);
                 })
                 .withMaxStackSize(6)
-                .withTextureName("Dummy.png").build(MWC.modContext, ItemMagazine.class);
+                .withTextureName("Dummy.png").build(modContext, ItemMagazine.class);
 
     }
 

--- a/src/main/java/com/paneedah/weaponlib/BulletHoleRenderer.java
+++ b/src/main/java/com/paneedah/weaponlib/BulletHoleRenderer.java
@@ -19,7 +19,6 @@ import static com.paneedah.mwc.ProjectConstants.ID;
 public class BulletHoleRenderer {
 
     private final LinkedBlockingQueue<BulletHole> holeQueue = new LinkedBlockingQueue<>();
-    private final ArrayList<BulletHole> bulletHoles = new ArrayList<>();
 
     public static class BulletHole {
         private final Vector3D pos;

--- a/src/main/java/com/paneedah/weaponlib/CommonEventHandler.java
+++ b/src/main/java/com/paneedah/weaponlib/CommonEventHandler.java
@@ -11,6 +11,7 @@ import com.paneedah.weaponlib.crafting.CraftingFileManager;
 import com.paneedah.weaponlib.electronics.ItemHandheld;
 import com.paneedah.weaponlib.jim.util.ByteArrayUtils;
 import com.paneedah.weaponlib.tracking.LivingEntityTracker;
+import lombok.Getter;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -51,16 +52,13 @@ import static com.paneedah.mwc.ProjectConstants.LOGGER;
  * - Re-factored class
  */
 // Todo: Cleanup this mess
+@Getter
 public class CommonEventHandler {
 
     private final ModContext modContext;
 
     public CommonEventHandler(ModContext modContext) {
         this.modContext = modContext;
-    }
-
-    public ModContext getModContext() {
-        return modContext;
     }
 
     @SubscribeEvent

--- a/src/main/java/com/paneedah/weaponlib/HighIQSpawnEgg.java
+++ b/src/main/java/com/paneedah/weaponlib/HighIQSpawnEgg.java
@@ -1,5 +1,6 @@
 package com.paneedah.weaponlib;
 
+import com.paneedah.mwc.ProjectConstants;
 import com.paneedah.weaponlib.compatibility.ModelRegistryServerInterchange;
 import com.paneedah.weaponlib.crafting.CraftingEntry;
 import com.paneedah.weaponlib.crafting.CraftingGroup;
@@ -142,7 +143,7 @@ public class HighIQSpawnEgg extends Item implements ICraftingRecipe {
 
                 return EnumActionResult.SUCCESS;
             } catch (Exception e) {
-                System.err.println("Unable to spawn entity with name: " + getEntitySpawnName());
+                ProjectConstants.LOGGER.error("Unable to spawn entity with name: {}", getEntitySpawnName());
             }
 
             return super.onItemUse(player, worldIn, pos, hand, facing, hitX, hitY, hitZ);

--- a/src/main/java/com/paneedah/weaponlib/HighIQSpawnEgg.java
+++ b/src/main/java/com/paneedah/weaponlib/HighIQSpawnEgg.java
@@ -1,6 +1,5 @@
 package com.paneedah.weaponlib;
 
-import com.paneedah.mwc.ProjectConstants;
 import com.paneedah.weaponlib.compatibility.ModelRegistryServerInterchange;
 import com.paneedah.weaponlib.crafting.CraftingEntry;
 import com.paneedah.weaponlib.crafting.CraftingGroup;
@@ -27,7 +26,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 import java.util.function.Predicate;
 
-import static com.paneedah.mwc.ProjectConstants.ID;
+import static com.paneedah.mwc.ProjectConstants.*;
 
 @NoArgsConstructor
 public class HighIQSpawnEgg extends Item implements ICraftingRecipe {
@@ -143,7 +142,7 @@ public class HighIQSpawnEgg extends Item implements ICraftingRecipe {
 
                 return EnumActionResult.SUCCESS;
             } catch (Exception e) {
-                ProjectConstants.LOGGER.error("Unable to spawn entity with name: {}", getEntitySpawnName());
+                LOGGER.error("Unable to spawn entity with name: {}", getEntitySpawnName());
             }
 
             return super.onItemUse(player, worldIn, pos, hand, facing, hitX, hitY, hitZ);

--- a/src/main/java/com/paneedah/weaponlib/ai/BetterAINearestAttackableTarget.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/BetterAINearestAttackableTarget.java
@@ -25,7 +25,6 @@ public class BetterAINearestAttackableTarget<T extends EntityLivingBase> extends
 
     public BetterAINearestAttackableTarget(EntityCreature creature, Class<T> classTarget, String name, boolean checkSight) {
         super(creature, classTarget, checkSight);
-        // TODO Auto-generated constructor stub
         this.enemyName = name;
     }
 

--- a/src/main/java/com/paneedah/weaponlib/ai/EntityAIAttackRangedWeapon.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/EntityAIAttackRangedWeapon.java
@@ -1,7 +1,9 @@
 package com.paneedah.weaponlib.ai;
 
+import com.paneedah.mwc.Grenades;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.item.Item;
 import net.minecraft.util.EnumHand;
 
 import java.util.Collections;
@@ -22,8 +24,6 @@ public class EntityAIAttackRangedWeapon extends EntityAIBase {
     private int strafingTime = -1;
     private final Set<Class<?>> attackWithItemType;
     private final float secondaryEquipmentUseChance;
-
-    private float lookHeightMultiplier;
 
     public EntityAIAttackRangedWeapon(EntityCustomMob customMob,
                                       double speedAmplifier, int delay, float maxDistance,
@@ -59,10 +59,30 @@ public class EntityAIAttackRangedWeapon extends EntityAIBase {
     }
 
     protected boolean isItemTypeInMainHand() {
-        return entity.getHeldItemMainhand() != null
-                && (attackWithItemType.isEmpty()
-                || attackWithItemType.stream().anyMatch(a -> a.isInstance(entity.getHeldItemMainhand().getItem())));
+        if (entity.getHeldItemMainhand().isEmpty()) {
+            return false;
+        }
+
+        Item heldItem = entity.getHeldItemMainhand().getItem();
+
+        // Check if the held item matches a allowed item
+        boolean matchesAllowedType = attackWithItemType.isEmpty() || attackWithItemType.stream().anyMatch(a -> a.isInstance(heldItem));
+
+        // Check for grenades
+        boolean isSpecificItem = isHoldingSpecificItem(Grenades.FuseGrenade) || isHoldingSpecificItem(Grenades.ImpactGrenade) || isHoldingSpecificItem(Grenades.SmokeGrenade) || isHoldingSpecificItem(Grenades.GasGrenade) || isHoldingSpecificItem(Grenades.FlashGrenade);
+
+        return matchesAllowedType || isSpecificItem;
     }
+
+    /**
+     * Checks if the entity is holding an item
+     *
+     * @param targetItem the Item to check for
+     */
+    protected boolean isHoldingSpecificItem(Item targetItem) {
+        return !entity.getHeldItemMainhand().isEmpty() && entity.getHeldItemMainhand().getItem() == targetItem;
+    }
+
 
     /**
      * Returns whether an in-progress EntityAIBase should continue executing
@@ -99,9 +119,7 @@ public class EntityAIAttackRangedWeapon extends EntityAIBase {
         EntityLivingBase attackTarget = this.entity.getAttackTarget();
 
         if (attackTarget != null) {
-
             this.entity.getLookHelper().setLookPosition(attackTarget.posX, attackTarget.posY + attackTarget.getEyeHeight() * this.entity.getConfiguration().getLookHeightMultiplier(), attackTarget.posZ, 30f, 30f);
-            //this.entity.getLookHelper().setLookPositionWithEntity(attackTarget, 30.0F, 30.0F);
 
             double d0 = this.entity.getDistanceSq(attackTarget.posX, attackTarget.getEntityBoundingBox().minY, attackTarget.posZ);
             boolean canSeeTarget = this.entity.getEntitySenses().canSee(attackTarget);
@@ -111,11 +129,7 @@ public class EntityAIAttackRangedWeapon extends EntityAIBase {
                 this.seeTime = 0;
             }
 
-            if (canSeeTarget) {
-                ++this.seeTime;
-            } else {
-                --this.seeTime;
-            }
+            this.seeTime += canSeeTarget ? 1 : -1;
 
             if (d0 <= (double) this.maxAttackDistanceSquared && this.seeTime >= 20) {
                 this.entity.getNavigator().clearPath();
@@ -125,49 +139,59 @@ public class EntityAIAttackRangedWeapon extends EntityAIBase {
                 this.strafingTime = -1;
             }
 
-            if (this.strafingTime >= 20) {
-                if ((double) this.entity.getRNG().nextFloat() < 0.3D) {
-                    this.strafingClockwise = !this.strafingClockwise;
-                }
+            updateStrafingDirection();
+            executeStrafing(d0);
+            handleAttack(attackTarget, canSeeTarget);
+        }
+    }
 
-                if ((double) this.entity.getRNG().nextFloat() < 0.3D) {
-                    this.strafingBackwards = !this.strafingBackwards;
-                }
+    private void updateStrafingDirection() {
+        if (this.strafingTime >= 20) {
+            if (this.entity.getRNG().nextFloat() < 0.3D) {
+                this.strafingClockwise = !this.strafingClockwise;
+            }
+            if (this.entity.getRNG().nextFloat() < 0.3D) {
+                this.strafingBackwards = !this.strafingBackwards;
+            }
+            this.strafingTime = 0;
+        }
+    }
 
-                this.strafingTime = 0;
+    private void executeStrafing(double distanceSq) {
+        if (this.strafingTime > -1) {
+            if (distanceSq > (double) (this.maxAttackDistanceSquared * 0.75F)) {
+                this.strafingBackwards = false;
+            } else if (distanceSq < (double) (this.maxAttackDistanceSquared * 0.25F)) {
+                this.strafingBackwards = true;
             }
 
-            if (this.strafingTime > -1) {
-                if (d0 > (double) (this.maxAttackDistanceSquared * 0.75F)) {
-                    this.strafingBackwards = false;
-                } else if (d0 < (double) (this.maxAttackDistanceSquared * 0.25F)) {
-                    this.strafingBackwards = true;
-                }
+            float forward = this.strafingBackwards ? -0.5F : 0.5F;
+            float strafe = this.strafingClockwise ? 0.5F : -0.5F;
+            this.entity.getMoveHelper().strafe(forward, strafe);
+            this.entity.faceEntity(this.entity.getAttackTarget(), 30.0F, 30.0F);
+        } else {
+            this.entity.getLookHelper().setLookPositionWithEntity(this.entity.getAttackTarget(), 30.0F, 30.0F);
+        }
+    }
 
-                this.entity.getMoveHelper().strafe(this.strafingBackwards ? -0.5F : 0.5F, this.strafingClockwise ? 0.5F : -0.5F);
-                this.entity.faceEntity(attackTarget, 30.0F, 30.0F);
-            } else {
-                this.entity.getLookHelper().setLookPositionWithEntity(attackTarget, 30.0F, 30.0F);
-            }
-
-            if (this.entity.isHandActive()) {
-                if (!canSeeTarget && this.seeTime < -60) {
+    private void handleAttack(EntityLivingBase attackTarget, boolean canSeeTarget) {
+        if (this.entity.isHandActive()) {
+            if (!canSeeTarget && this.seeTime < -60) {
+                this.entity.resetActiveHand();
+            } else if (canSeeTarget) {
+                if (Math.abs((-(this.entity.posX - attackTarget.posX) / (this.entity.posZ - attackTarget.posZ)) - Math.tan(this.entity.renderYawOffset / 180f * Math.PI)) < 5.0) {
                     this.entity.resetActiveHand();
-                } else if (canSeeTarget) {
-                    if (Math.abs((-(this.entity.posX - attackTarget.posX) / (this.entity.posZ - attackTarget.posZ)) - Math.tan(this.entity.renderYawOffset / 180f * Math.PI)) < 5.0) {
-                        this.entity.resetActiveHand();
-                        if (entity.getSecondaryEquipment() != null && entity.getRNG().nextFloat() < secondaryEquipmentUseChance) {
-                            this.entity.attackWithSecondaryEquipment(attackTarget, 0); // TODO: set some distance factor
-                        } else {
-                            this.entity.attackEntityWithRangedAttack(attackTarget, 0);
-                            // TODO: set some distance factor
-                        }
-                        this.attackTime = (this.attackCooldown >> 1) + this.entity.getRNG().nextInt(this.attackCooldown << 1);
+                    if (entity.getSecondaryEquipment() != null && entity.getRNG().nextFloat() < secondaryEquipmentUseChance) {
+                        this.entity.attackWithSecondaryEquipment(attackTarget, 0); // TODO: set some distance factor
+                    } else {
+                        this.entity.attackEntityWithRangedAttack(attackTarget, 0);
+                        // TODO: set some distance factor
                     }
+                    this.attackTime = (this.attackCooldown >> 1) + this.entity.getRNG().nextInt(this.attackCooldown << 1);
                 }
-            } else if (--this.attackTime <= 0 && this.seeTime >= -60) {
-                this.entity.setActiveHand(EnumHand.MAIN_HAND);
             }
+        } else if (--this.attackTime <= 0 && this.seeTime >= -60) {
+            this.entity.setActiveHand(EnumHand.MAIN_HAND);
         }
     }
 }

--- a/src/main/java/com/paneedah/weaponlib/ai/EntityConfiguration.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/EntityConfiguration.java
@@ -2,6 +2,7 @@ package com.paneedah.weaponlib.ai;
 
 import com.paneedah.weaponlib.*;
 import com.paneedah.weaponlib.config.ModernConfigManager;
+import lombok.Getter;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.EntityAIBase;
@@ -605,74 +606,50 @@ public class EntityConfiguration {
         }
     }
 
-    private WeightedOptions<EnumDifficulty, Equipment> equipmentOptions;
-    private WeightedOptions<EnumDifficulty, Equipment> secondaryEquipmentOptions;
+    @Getter private WeightedOptions<EnumDifficulty, Equipment> equipmentOptions;
+    @Getter private WeightedOptions<EnumDifficulty, Equipment> secondaryEquipmentOptions;
 
     private List<AiTask> aiTasks;
     private List<AiTask> aiTargetTasks;
-    private SoundEvent ambientSound;
-    private SoundEvent hurtSound;
-    private SoundEvent deathSound;
-    private SoundEvent stepSound;
-    private ResourceLocation lootTable;
-    private double maxHealth;
-    private Predicate<Entity> canSpawnHere;
+    @Getter private SoundEvent ambientSound;
+    @Getter private SoundEvent hurtSound;
+    @Getter private SoundEvent deathSound;
+    @Getter private SoundEvent stepSound;
+    @Getter private ResourceLocation lootTable;
+    @Getter private double maxHealth;
+    @Getter private Predicate<Entity> canSpawnHere;
     private Predicate<Entity> isValidLightLevel;
-    private EnumCreatureAttribute creatureAttribute;
-    private float maxTolerableLightBrightness;
-    private double maxSpeed;
-    private List<TexturedModel> texturedModelVariants;
-    private double followRange;
-    private double collisionAttackDamage;
+    @Getter private EnumCreatureAttribute creatureAttribute;
+    @Getter private float maxTolerableLightBrightness;
+    @Getter private double maxSpeed;
+    @Getter private List<TexturedModel> texturedModelVariants;
+    @Getter private double followRange;
+    @Getter private double collisionAttackDamage;
 
     private boolean isPushable;
     private boolean isInvulnerable;
     private boolean isCollidable;
     private boolean isDespawnable;
 
-    public float lookHeightMultiplier;
+    @Getter public float lookHeightMultiplier;
 
-    public float sizeWidth, sizeHeight;
+    @Getter public float sizeWidth, sizeHeight;
 
     private Map<EntityEquipmentSlot, CustomArmor> armor;
-    private float primaryEquipmentDropChance;
-    private float secondaryEquipmentDropChance;
-    private float armorDropChance;
-    private int maxAmmo;
+    @Getter private float primaryEquipmentDropChance;
+    @Getter private float secondaryEquipmentDropChance;
+    @Getter private float armorDropChance;
+    @Getter private int maxAmmo;
 
-    private CustomMobAttack collisionAttack;
-    private CustomMobAttack delayedAttack;
+    @Getter private CustomMobAttack collisionAttack;
+    @Getter private CustomMobAttack delayedAttack;
 
-    private String mobName;
+    @Getter private String mobName;
 
 
-    private int pickupItemID = -1;
+    @Getter private int pickupItemID = -1;
 
     protected EntityConfiguration() {}
-
-    public String getMobName() {
-        return this.mobName;
-    }
-
-    public WeightedOptions<EnumDifficulty, Equipment> getEquipmentOptions() {
-        return equipmentOptions;
-    }
-
-    public WeightedOptions<EnumDifficulty, Equipment> getSecondaryEquipmentOptions() {
-        return secondaryEquipmentOptions;
-    }
-
-    public float getSizeWidth() {
-        return this.sizeWidth;
-    }
-
-    public float getSizeHeight() {
-        return this.sizeHeight;
-    }
-
-    public int getPickupItemID() {
-        return this.pickupItemID;
-    }
 
     public void addAiTasks(EntityLiving e, EntityAITasks tasks) {
         aiTasks.stream().forEach(t -> tasks.addTask(t.priority, t.taskSupplier.apply(e)));
@@ -682,92 +659,12 @@ public class EntityConfiguration {
         aiTargetTasks.stream().forEach(t -> tasks.addTask(t.priority, t.taskSupplier.apply(e)));
     }
 
-    public float getLookHeightMultiplier() {
-        return this.lookHeightMultiplier;
-    }
-
-    public SoundEvent getAmbientSound() {
-        return ambientSound;
-    }
-
-    public SoundEvent getHurtSound() {
-        return hurtSound;
-    }
-
-    public SoundEvent getDeathSound() {
-        return deathSound;
-    }
-
-    public SoundEvent getStepSound() {
-        return stepSound;
-    }
-
-    public ResourceLocation getLootTable() {
-        return lootTable;
-    }
-
-    public double getMaxHealth() {
-        return maxHealth;
-    }
-
-    public Predicate<Entity> getCanSpawnHere() {
-        return canSpawnHere;
-    }
-
     public Predicate<Entity> isValidLightLevel() {
         return isValidLightLevel;
     }
 
-    public EnumCreatureAttribute getCreatureAttribute() {
-        return creatureAttribute;
-    }
-
-    public float getMaxTolerableLightBrightness() {
-        return maxTolerableLightBrightness;
-    }
-
-    public double getMaxSpeed() {
-        return maxSpeed;
-    }
-
-    public double getFollowRange() {
-        return followRange;
-    }
-
-    public List<TexturedModel> getTexturedModelVariants() {
-        return texturedModelVariants;
-    }
-
     public Collection<CustomArmor> getArmorSet() {
         return armor.values();
-    }
-
-    public float getPrimaryEquipmentDropChance() {
-        return primaryEquipmentDropChance;
-    }
-
-    public float getSecondaryEquipmentDropChance() {
-        return secondaryEquipmentDropChance;
-    }
-
-    public float getArmorDropChance() {
-        return armorDropChance;
-    }
-
-    public int getMaxAmmo() {
-        return maxAmmo;
-    }
-
-    public CustomMobAttack getCollisionAttack() {
-        return collisionAttack;
-    }
-
-    public CustomMobAttack getDelayedAttack() {
-        return delayedAttack;
-    }
-
-    public double getCollisionAttackDamage() {
-        return collisionAttackDamage;
     }
 
     public boolean isPushable() {

--- a/src/main/java/com/paneedah/weaponlib/ai/EntityConfiguration.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/EntityConfiguration.java
@@ -2,6 +2,7 @@ package com.paneedah.weaponlib.ai;
 
 import com.paneedah.weaponlib.*;
 import com.paneedah.weaponlib.config.ModernConfigManager;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.entity.*;
@@ -9,6 +10,7 @@ import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemArmor;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.EnumDifficulty;
@@ -61,18 +63,12 @@ public class EntityConfiguration {
 
     public static class Builder {
 
+        @AllArgsConstructor
         private static class Spawn {
             int weightedProb;
             int min;
             int max;
             BiomeDictionary.Type[] biomeTypes;
-
-            public Spawn(int weightedProb, int min, int max, BiomeDictionary.Type[] biomeTypes) {
-                this.weightedProb = weightedProb;
-                this.min = min;
-                this.max = max;
-                this.biomeTypes = biomeTypes;
-            }
         }
 
         private static class EquipmentValue {
@@ -179,7 +175,7 @@ public class EntityConfiguration {
         private boolean spawnEgg;
         private int primaryEggColor;
         private int secondaryEggColor;
-        private final Map<EntityEquipmentSlot, CustomArmor> armor = new HashMap<>();
+        private final Map<EntityEquipmentSlot, ItemArmor> armor = new HashMap<>();
 
         private float primaryEquipmentDropChance = DEFAULT_PRIMARY_EQUIPMENT_DROP_CHANCE;
         private float secondaryEquipmentDropChance = DEFAULT_SECONDARY_EQUIPMENT_DROP_CHANCE;
@@ -276,8 +272,8 @@ public class EntityConfiguration {
             return this;
         }
 
-        public Builder withArmor(CustomArmor armor) {
-            this.armor.put(armor.getCompatibleEquipmentSlot(), armor);
+        public Builder withArmor(ItemArmor armor) {
+            this.armor.put(armor.getEquipmentSlot(), armor);
             return this;
         }
 
@@ -635,7 +631,7 @@ public class EntityConfiguration {
 
     @Getter public float sizeWidth, sizeHeight;
 
-    private Map<EntityEquipmentSlot, CustomArmor> armor;
+    private Map<EntityEquipmentSlot, ItemArmor> armor;
     @Getter private float primaryEquipmentDropChance;
     @Getter private float secondaryEquipmentDropChance;
     @Getter private float armorDropChance;
@@ -663,7 +659,7 @@ public class EntityConfiguration {
         return isValidLightLevel;
     }
 
-    public Collection<CustomArmor> getArmorSet() {
+    public Collection<ItemArmor> getArmorSet() {
         return armor.values();
     }
 

--- a/src/main/java/com/paneedah/weaponlib/ai/EntityCustomMob.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/EntityCustomMob.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.stats.StatList;
@@ -258,8 +259,8 @@ public class EntityCustomMob extends EntityMob implements IRangedAttackMob, Cont
     private void setArmorEquipment() {
         EntityConfiguration configuration = getConfiguration();
         Arrays.fill(this.inventoryArmorDropChances, configuration.getArmorDropChance());
-        for (CustomArmor armor : configuration.getArmorSet()) {
-            this.setItemStackToSlot(armor.getCompatibleEquipmentSlot(), new ItemStack(armor));
+        for (ItemArmor armor : configuration.getArmorSet()) {
+            this.setItemStackToSlot(armor.getEquipmentSlot(), new ItemStack(armor));
         }
     }
 

--- a/src/main/java/com/paneedah/weaponlib/ai/EntityCustomMob.java
+++ b/src/main/java/com/paneedah/weaponlib/ai/EntityCustomMob.java
@@ -8,6 +8,7 @@ import com.paneedah.weaponlib.ai.EntityConfiguration.TexturedModel;
 import com.paneedah.weaponlib.compatibility.CompatibleDataManager;
 import com.paneedah.weaponlib.grenade.GrenadeAttackAspect;
 import com.paneedah.weaponlib.grenade.ItemGrenade;
+import lombok.Getter;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.entity.*;
@@ -52,7 +53,7 @@ public class EntityCustomMob extends EntityMob implements IRangedAttackMob, Cont
 
     private EntityConfiguration configuration;
 
-    private ItemStack secondaryEquipment;
+    @Getter private ItemStack secondaryEquipment;
 
     private int delayedAttackTimer;
 
@@ -566,10 +567,6 @@ public class EntityCustomMob extends EntityMob implements IRangedAttackMob, Cont
     @Override
     public void setContext(ModContext modContext) {
         this.modContext = modContext;
-    }
-
-    public ItemStack getSecondaryEquipment() {
-        return secondaryEquipment;
     }
 
     public void setDelayedAttackTimerIncrement(int increment) {

--- a/src/main/java/com/paneedah/weaponlib/animation/SpecialAttachments.java
+++ b/src/main/java/com/paneedah/weaponlib/animation/SpecialAttachments.java
@@ -7,7 +7,7 @@ import com.paneedah.weaponlib.model.Bullet556;
 public class SpecialAttachments {
     public static ItemAttachment<Weapon> MagicMag;
 
-    public static void init(Object mod, ModContext context) {
+    public static void init(ModContext modContext) {
 
         MagicMag = new AttachmentBuilder<Weapon>()
                 .withCategory(AttachmentCategory.MAGICMAG)
@@ -18,7 +18,7 @@ public class SpecialAttachments {
 
                 .withName("magazine_extra")
                 .withRenderablePart()
-                .withTextureName("Dummy.png").build(context);
+                .withTextureName("Dummy.png").build(modContext);
 
 
     }

--- a/src/main/java/com/paneedah/weaponlib/debug/DebugRenderer.java
+++ b/src/main/java/com/paneedah/weaponlib/debug/DebugRenderer.java
@@ -4,13 +4,22 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.math.Vec3d;
 import org.lwjgl.opengl.GL11;
 
+/**
+ * The Debug Renderer for MWC, used for rendering debug information
+ */
 public class DebugRenderer {
 
+    /**
+     * Setup the renderer, make sure you call {@link #destructBasicRender} when you are done
+     */
     public static void setupBasicRender() {
         GlStateManager.disableCull();
         GlStateManager.disableTexture2D();
     }
 
+    /**
+     * Deconstruct the renderer
+     */
     public static void destructBasicRender() {
         GlStateManager.enableCull();
         GlStateManager.enableTexture2D();

--- a/src/main/java/com/paneedah/weaponlib/tile/CustomTileEntity.java
+++ b/src/main/java/com/paneedah/weaponlib/tile/CustomTileEntity.java
@@ -1,6 +1,7 @@
 package com.paneedah.weaponlib.tile;
 
 import com.paneedah.weaponlib.Configurable;
+import lombok.Getter;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
@@ -15,7 +16,7 @@ public class CustomTileEntity<T extends CustomTileEntityConfiguration<T>> extend
 
     protected CustomTileEntityConfiguration<?> configuration;
 
-    private int side;
+    @Getter private int side;
 
 
     private T safeCast(Object input) {
@@ -32,10 +33,6 @@ public class CustomTileEntity<T extends CustomTileEntityConfiguration<T>> extend
 
     protected void setSide(int side) {
         this.side = side;
-    }
-
-    public int getSide() {
-        return side;
     }
 
     public void onEntityBlockActivated(World world, BlockPos pos, EntityPlayer player) {

--- a/src/main/java/com/paneedah/weaponlib/tile/CustomTileEntityClassFactory.java
+++ b/src/main/java/com/paneedah/weaponlib/tile/CustomTileEntityClassFactory.java
@@ -1,5 +1,6 @@
 package com.paneedah.weaponlib.tile;
 
+import lombok.Getter;
 import net.minecraft.tileentity.TileEntity;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
@@ -31,11 +32,7 @@ public class CustomTileEntityClassFactory implements Opcodes {
         }
     }
 
-    private static final CustomTileEntityClassFactory instance = new CustomTileEntityClassFactory();
-
-    public static CustomTileEntityClassFactory getInstance() {
-        return instance;
-    }
+    @Getter private static final CustomTileEntityClassFactory instance = new CustomTileEntityClassFactory();
 
     private final Map<Class<?>, CustomTileEntityConfiguration<?>> entityConfigurations = new HashMap<>();
 


### PR DESCRIPTION
## 📝 Description

Improve Registration of items, and slightly cleanup NPC behavior 

## 🎯 Goals

- Move as many init stuff to CommonProxy.init as possible 
- Remove unused "Object mod" arguments
- Use a ModContext argument whenever possible 
- Prevent NPC's from attacking with grenades 
- Cleanup EntityAIAttackRangedWeapon and EntityConfiguration

## ❌ Non Goals

- New NPC's, new NPC behavior 
- Loading bars for items

## 🚦 Testing 

- NPC's still behave in the same way

## ⏮️ Backwards Compatibility 

- No issues with existing worlds

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed