### PR TITLE
Add Funny Lang

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -63,6 +63,9 @@ like knowing which weapon is better or whether an attachment will be useful to y
   - Added helper methods to avoid typing enums strings
   - Added more validations
 - Added support for the ore dictionary
+- Added language translation for:
+  - Pirate Speak (The Seven Seas)
+  - Shakespearean English (Kingdom of England)
 
 ### Changed
 

--- a/src/main/resources/assets/mwc/lang/en_PT.lang
+++ b/src/main/resources/assets/mwc/lang/en_PT.lang
@@ -1,0 +1,116 @@
+item.m40gasmask_helmet.name=Breather o’ the M40 Deep
+item.JPNVG18_helmet.name=Night-Seer’s Helm o’ GPNVG-18
+
+item.audis4.name=Audi S4, Me Land-Sharkin’ Carriage
+item.MClaren_senna.name=McLaren’s Thunderin’ Steed, Aye, Senna!
+item.ae86trueno.name=AE86 Trueno, Fleet Chariot o’ the East Winds
+item.atv_polaris_sportsman_850_2019.name=Polaris 850 ‘O Nineteen Past Twenty Hundred
+
+entity.${id}_terrorist.name=Scurvy Dog from the East
+entity.${id}_soldier.name=Ironclad Matey o’ War
+
+item.${id}_gas-detector.name=Sniffer o’ the Stinkin’ Fog
+item.${id}_GasGrenade.name=Stinkbomb o’ Deathly Breeze
+
+item.Marine_helmet.name=Helm o’ the Tan Marines
+item.Marine_chest.name=Mail o’ the Tan Marines
+item.Marine_boots.name=Boots o’ the Tan Marines
+
+item.Spec_Ops_helmet.name=Helm o’ the Black Shadows
+item.Spec_Ops_chest.name=Mail o’ the Black Shadows
+item.Spec_Ops_boots.name=Boots o’ the Black Shadows
+
+item.Spetznaz_helmet.name=Helm o’ the Forest Crew
+item.Spetznaz_chest.name=Mail o’ the Forest Crew
+item.Spetznaz_boots.name=Boots o’ the Forest Crew
+
+item.Urban_helmet.name=Helm o’ the Concrete Raiders
+item.Urban_chest.name=Mail o’ the Concrete Raiders
+item.Urban_boots.name=Boots o’ the Concrete Raiders
+
+item.ghillie_helmet.name=Helm o’ the Mossy Sneak
+item.ghillie_chest.name=Mail o’ the Mossy Sneak
+item.ghillie_boots.name=Boots o’ the Mossy Sneak
+
+item.Swat_helmet.name=Helm o’ the Lawmen
+item.Swat_chest.name=Mail o’ the Lawmen
+item.Swat_boots.name=Boots o’ the Lawmen
+
+item.Nazisanta_helmet.name=Helm o’ the Cursèd Claus
+item.Nazisanta_chest.name=Mail o’ the Cursèd Claus
+item.Nazisanta_boots.name=Boots o’ the Cursèd Claus
+
+item.Santa_helmet.name=Helm o’ Cap’n Kringle
+item.Santa_chest.name=Mail o’ Cap’n Kringle
+item.Santa_boots.name=Boots o’ Cap’n Kringle
+
+item.Juggernaut_helmet.name=Helm o’ the Steel Juggernaut
+item.Juggernaut_chest.name=Mail o’ the Steel Juggernaut
+item.Juggernaut_boots.name=Boots o’ the Steel Juggernaut
+
+item.Astronaut_helmet.name=Helm o’ the Sky Rover
+item.Astronaut_chest.name=Mail o’ the Sky Rover
+item.Astronaut_boots.name=Boots o’ the Sky Rover
+
+item.SCPGuard_helmet.name=Helm o’ the Watcher Guard
+item.SCPGuard_chest.name=Mail o’ the Watcher Guard
+item.SCPGuard_boots.name=Boots o’ the Watcher Guard
+
+item.Dclass_chest.name=Mail o’ the Doomed Deckhand
+item.Dclass_boots.name=Boots o’ the Doomed Deckhand
+
+item.${id}_combat_sustainment_backpack_tan.name=Tan Sack o’ Lastin’ Rations
+item.${id}_combat_sustainment_backpack_black.name=Black Sack o’ Long-Haulin’
+item.${id}_combat_sustainment_backpack_forest.name=Camouflage’d Sack o’ Bush Survival
+
+item.${id}_assault_backpack_tan.name=Tan Ruck o’ Rushin’ Glory
+item.${id}_assault_backpack_black.name=Dark Bag o’ Sudden Mayhem
+item.${id}_assault_backpack_forest.name=Forest-Fleck’d Bag o’ Raidin’
+
+item.${id}_tru_spec_cordura_backpack_tan.name=Tan Satchel o’ Cordura’d Craftin’
+item.${id}_tru_spec_cordura_backpack_black.name=Pitch-Hued Satchel o’ Tough Hide
+item.${id}_tru_spec_cordura_backpack_forest.name=Satchel Blended with Leaf ‘n’ Earth
+
+item.${id}_f5_switchblade_backpack.name=Pack o’ F5, Blade That Folds Like a Flag
+
+item.${id}_duffle_bag.name=Sailor’s Sack o’ Many Plunders
+
+item.${id}_flyye_field_compact_plate_carrier.name=Molle’s Buckler o’ the Tight Fit
+item.${id}_molle_black.name=Molle’s Gear (Dark as Davy Jones’ Locker)
+item.${id}_molle_green.name=Molle’s Vest (Like a Mossy Mast)
+item.${id}_molle_urban.name=Molle’s Vest (Grey like a Stormy Dock)
+
+item.${id}_fort_armor.name=Iron Shell o’ 6B43 6A, Mightier than the Kraken’s Grip
+
+item.${id}_usMC_vest.name=Vest o’ the Recon Raiders
+item.${id}_usMC_vest_black.name=Vest o’ the Black-Booted Marines
+item.${id}_usMC_vest_green.name=Vest from the Jungle’d Coasts
+item.${id}_usMC_vest_urban.name=Vest o’ the Cobblestone Battles
+
+item.${id}_swat_vest.name=Battle Gear UTG-547, Trusty as a Ship’s Wheel
+
+item.${id}_m43a_chest_harness.name=Harness of M43A, Strapped and Ready
+
+item.tactical_tomahawk.name=Boardin’ Axe o’ Tactics
+item.baseball_bat.name=Club o’ Ye Sportin’ Sort
+item.baseball_bat_nails.name=Spiky Club Fer Skull-Bustin’
+item.night_stick.name=Blackjack o’ the Night Watch
+
+item.${id}_wcam.name=Lookin’-Glass o’ Memories Froze
+item.${id}_tablet.name=Glowin’ Slab o’ Pirate Wisdom
+
+item.${id}_M67Frag.name=Blast Bomb o’ M67
+item.${id}_ImpactGrenade.name=Kaboom Orb o’ Sudden Doom
+item.${id}_M18White.name=Fog Orb o’ M18 (White as a Ghost Ship)
+item.${id}_Flash.name=Blindin’ Bomb o’ the Devil’s Light
+
+death.attack.gun=%s took a shot from %s usin’ %s
+death.attack.gun.noshooter=%s got blown to bits by %s
+
+itemGroup.weapons=Tools o’ Plunder
+itemGroup.props=Props Fer Actin’
+itemGroup.ammunitionAndMagazines=Boom-Sticks & Shot Rolls
+itemGroup.attachments=Add-Ons o’ Mayhem
+itemGroup.equipment=Gear o’ the Bold Buccaneer
+itemGroup.throwables=Tossables o’ Chaos
+itemGroup.blocksAndIngots=Plundered Blocks & Bars o’ Booty

--- a/src/main/resources/assets/mwc/lang/en_WS.lang
+++ b/src/main/resources/assets/mwc/lang/en_WS.lang
@@ -1,0 +1,125 @@
+item.m40gasmask_helmet.name=Breath’d Visor of M40
+item.JPNVG18_helmet.name=Helm of GPNVG-18, Seer of the Night
+
+item.audis4.name=Chariot of Ye Audi S4
+item.MClaren_senna.name=Steed of McLaren, Called Senna
+item.ae86trueno.name=Toyota AE86 Trueno, Stallion of Speed
+item.atv_polaris_sportsman_850_2019.name=Polaris Sportsman 850 of the Year Two-Thousand and Nineteen
+
+entity.${id}_terrorist.name=Rogue of the Eastern Lands
+entity.${id}_soldier.name=Knight of Iron Will
+
+item.${id}_gas-detector.name=Sniffer of Foul Vapours
+item.${id}_GasGrenade.name=Orb of Poison’d Mist
+
+item.Marine_helmet.name=Helm of Tan’d Valor
+item.Marine_chest.name=Jerkin of Battle (Tan)
+item.Marine_boots.name=Boots of Marching (Tan)
+
+item.Spec_Ops_helmet.name=Helm of Shadow’d Valor
+item.Spec_Ops_chest.name=Jerkin of Battle (Black)
+item.Spec_Ops_boots.name=Boots of Marching (Black)
+
+item.Spetznaz_helmet.name=Helm of Green’d Might
+item.Spetznaz_chest.name=Jerkin of Battle (Forest)
+item.Spetznaz_boots.name=Boots of Marching (Forest)
+
+item.Urban_helmet.name=Helm of Concrete’d Courage
+item.Urban_chest.name=Jerkin of Battle (Urban)
+item.Urban_boots.name=Boots of Marching (Urban)
+
+item.ghillie_helmet.name=Hood of the Hidden Hunter
+item.ghillie_chest.name=Fatigues of the Hidden Hunter
+item.ghillie_boots.name=Boots of Moss'd Path
+
+item.blackcamo_chest.name=Shirt of Nightshade’d Threads
+item.forest_chest.name=Garb of Woodland Might
+
+item.blackjeans_boots.name=Britches Black with Boots Bold
+item.khakijeans_boots.name=Britches of Sand and Boots of Night
+
+item.Swat_helmet.name=Helm of the Order’s Embrace
+item.Swat_chest.name=Plate of Order’s Embrace
+item.Swat_boots.name=Boots of Lawful Pursuit
+
+item.Tactical_helmet.name=Visionary Goggles of the Night
+
+item.Nazisanta_helmet.name=Cap of the Wicked Claus
+item.Nazisanta_chest.name=Robes of the Wicked Claus
+item.Nazisanta_boots.name=Boots of the Wicked Claus
+
+item.Santa_helmet.name=Beret of Father Christmas
+item.Santa_chest.name=Robes of Father Christmas
+item.Santa_boots.name=Boots of Father Christmas
+
+item.Juggernaut_helmet.name=Helm of the Jugger’d Beast
+item.Juggernaut_chest.name=Breastplate of the Jugger’d Beast
+item.Juggernaut_boots.name=Boots of the Jugger’d Beast
+
+item.Astronaut_helmet.name=Helm of the Skyward Seeker
+item.Astronaut_chest.name=Chestplate of Skyward Seeker
+item.Astronaut_boots.name=Boots of the Skyward Seeker
+
+item.SCPGuard_helmet.name=Helm of the SCP Ward
+item.SCPGuard_chest.name=Chestguard of SCP Ward
+item.SCPGuard_boots.name=Boots of SCP Ward
+
+item.Dclass_chest.name=Jerkin of the D-Class Wretch
+item.Dclass_boots.name=Boots of the Doomed Servant
+
+item.${id}_combat_sustainment_backpack_tan.name=Pack of Sustenance (Tan’d)
+item.${id}_combat_sustainment_backpack_black.name=Pack of Sustenance (Of the Blackened Hide)
+item.${id}_combat_sustainment_backpack_forest.name=Pack of Sustenance (Camouflaged in Leaves)
+
+item.${id}_assault_backpack_tan.name=Pack of the Assault’d Vanguard (Tan’d)
+item.${id}_assault_backpack_black.name=Pack of the Assault’d Vanguard (Of the Blackened HideOf the Blackened Hide)
+item.${id}_assault_backpack_forest.name=Pack of the Assault’d Vanguard (Camouflaged in Leaves)
+
+item.${id}_tru_spec_cordura_backpack_tan.name=Satchel of Tru-Spec'd Hide (Tan)
+item.${id}_tru_spec_cordura_backpack_black.name=Satchel of Tru-Spec'd Hide (Dark)
+item.${id}_tru_spec_cordura_backpack_forest.name=Satchel of Tru-Spec'd Hide (Forest Dwelt)
+
+item.${id}_f5_switchblade_backpack.name=Pack of F5, the Blade that Foldeth
+
+item.${id}_duffle_bag.name=Sack of Many Things
+
+item.${id}_flyye_field_compact_plate_carrier.name=Raiment of Molle, The Compact’d Shield
+item.${id}_molle_black.name=Raiment of Molle (Of the Night’s Cloth)
+item.${id}_molle_green.name=Raiment of Molle (Leaf'd Like)
+item.${id}_molle_urban.name=Raiment of Molle (Stonelike Urban)
+
+item.${id}_fort_armor.name=Armor of 6B43 6A, the Bastion Strong
+
+item.${id}_usMC_vest.name=Vest of Force Reconnaissance
+item.${id}_usMC_vest_black.name=Vest of Force Reconnaissance (Of the Black Legion)
+item.${id}_usMC_vest_green.name=Vest of Force Reconnaissance (Forest Borne)
+item.${id}_usMC_vest_urban.name=Vest of Force Reconnaissance (Urban Campaign)
+
+item.${id}_swat_vest.name=Vest of UTG-547, Tactical and True
+
+item.${id}_m43a_chest_harness.name=Harness of the M43A Order
+
+item.tactical_tomahawk.name=Hatchet of Tactical Deeds
+item.baseball_bat.name=Club of Ye Ballgame
+item.baseball_bat_nails.name=Club of Nails and Wrath
+item.night_stick.name=Rod of the Watchman
+
+item.${id}_wcam.name=Machina of Still’d Sight
+item.${id}_tablet.name=Tablet of Arcane Light
+
+item.${id}_M67Frag.name=Grenado of M67, Fragment’d
+item.${id}_ImpactGrenade.name=Orb of Sudden Blasting
+item.${id}_M18White.name=Orb Vapour of M18 (Snow-Hued)
+item.${id}_Flash.name=Orb of Blinding Radiance
+
+death.attack.gun=%s wast smitten by %s with %s
+death.attack.gun.noshooter=%s wast smitten unto death with %s
+
+itemGroup.weapons=Instruments of War
+itemGroup.props=Stage Properties
+itemGroup.ammunitionAndMagazines=Shot & Scrolls of Powder
+itemGroup.attachments=Accoutrements
+itemGroup.equipment=Regalia of Battle
+itemGroup.throwables=Hurlèd Missives
+itemGroup.blocksAndIngots=Bricks & Bars of Ore
+

--- a/src/main/resources/assets/mwc/lang/en_WS.lang
+++ b/src/main/resources/assets/mwc/lang/en_WS.lang
@@ -72,7 +72,7 @@ item.${id}_combat_sustainment_backpack_black.name=Pack of Sustenance (Of the Bla
 item.${id}_combat_sustainment_backpack_forest.name=Pack of Sustenance (Camouflaged in Leaves)
 
 item.${id}_assault_backpack_tan.name=Pack of the Assault’d Vanguard (Tan’d)
-item.${id}_assault_backpack_black.name=Pack of the Assault’d Vanguard (Of the Blackened HideOf the Blackened Hide)
+item.${id}_assault_backpack_black.name=Pack of the Assault’d Vanguard (Of the Blackened Hide)
 item.${id}_assault_backpack_forest.name=Pack of the Assault’d Vanguard (Camouflaged in Leaves)
 
 item.${id}_tru_spec_cordura_backpack_tan.name=Satchel of Tru-Spec'd Hide (Tan)


### PR DESCRIPTION
## 📝 Description

Adds language translation for 
- Pirate Speak (The Seven Seas)
- Shakespearean English (Kingdom of England)

## 🎯 Goals

- Make the mod a little funnier 

## ❌ Non Goals

- Completely translate all items. This just does armor, creative tabs, death messages, grenades, and melee weapons

## 🚦 Testing 

Load game, change language, observe 

## ⏮️ Backwards Compatibility 

Works with old worlds

## 📚 Related Issues & Documents

N/A

## 🖼️ Screenshots/Recordings

<img width="1920" height="1171" alt="image" src="https://github.com/user-attachments/assets/4e1f9121-26ec-44ff-90da-d56ff62fd3a6" />


## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pirate-themed English (Portugal) localization with unique translations for in-game items, entities, and messages.
  * Introduced an archaic English localization variant featuring stylized names and thematic messages for game elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->