### PR TITLE
Move InventoryTab system out of weaponlib

### DIFF
--- a/src/main/java/com/paneedah/mwc/equipment/inventory/GuiEquipment.java
+++ b/src/main/java/com/paneedah/mwc/equipment/inventory/GuiEquipment.java
@@ -1,7 +1,7 @@
 package com.paneedah.mwc.equipment.inventory;
 
-import com.paneedah.weaponlib.inventory.CustomPlayerInventoryTab;
-import com.paneedah.weaponlib.inventory.InventoryTabs;
+import com.paneedah.mwc.gui.inventory.CustomPlayerInventoryTab;
+import com.paneedah.mwc.gui.inventory.InventoryTabHandler;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
@@ -33,10 +33,10 @@ public class GuiEquipment extends InventoryEffectRenderer {
 
         guiLeft = (width - xSize) / 2;
 
-        final InventoryTabs inventoryTabs = InventoryTabs.getInstance();
+        final InventoryTabHandler inventoryTabHandler = InventoryTabHandler.getInstance();
 
-        inventoryTabs.updateTabValues(guiLeft, guiTop, CustomPlayerInventoryTab.class);
-        inventoryTabs.addTabsToList(buttonList);
+        inventoryTabHandler.updateTabValues(guiLeft, guiTop, CustomPlayerInventoryTab.class);
+        inventoryTabHandler.addTabsToList(buttonList);
     }
 
     @Override

--- a/src/main/java/com/paneedah/mwc/equipment/inventory/carryable/backpack/GuiBackpack.java
+++ b/src/main/java/com/paneedah/mwc/equipment/inventory/carryable/backpack/GuiBackpack.java
@@ -1,7 +1,7 @@
 package com.paneedah.mwc.equipment.inventory.carryable.backpack;
 
-import com.paneedah.weaponlib.inventory.BackpackInventoryTab;
-import com.paneedah.weaponlib.inventory.InventoryTabs;
+import com.paneedah.mwc.gui.inventory.BackpackInventoryTab;
+import com.paneedah.mwc.gui.inventory.InventoryTabHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.util.ResourceLocation;
@@ -28,10 +28,10 @@ public class GuiBackpack extends GuiContainer {
     public void initGui() {
         super.initGui();
 
-        final InventoryTabs inventoryTabs = InventoryTabs.getInstance();
+        final InventoryTabHandler inventoryTabHandler = InventoryTabHandler.getInstance();
 
-        inventoryTabs.updateTabValues(guiLeft, guiTop, BackpackInventoryTab.class);
-        inventoryTabs.addTabsToList(this.buttonList);
+        inventoryTabHandler.updateTabValues(guiLeft, guiTop, BackpackInventoryTab.class);
+        inventoryTabHandler.addTabsToList(this.buttonList);
     }
 
     @Override

--- a/src/main/java/com/paneedah/mwc/gui/GuiHandler.java
+++ b/src/main/java/com/paneedah/mwc/gui/GuiHandler.java
@@ -1,4 +1,4 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui;
 
 import com.paneedah.mwc.capabilities.EquipmentCapability;
 import com.paneedah.mwc.equipment.inventory.EquipmentContainer;

--- a/src/main/java/com/paneedah/mwc/gui/inventory/BackpackInventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/BackpackInventoryTab.java
@@ -1,7 +1,8 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui.inventory;
 
 import com.paneedah.mwc.capabilities.EquipmentCapability;
 import com.paneedah.mwc.equipment.inventory.EquipmentInventory;
+import com.paneedah.mwc.gui.GuiHandler;
 import com.paneedah.mwc.items.equipment.carryable.ItemBackpack;
 import com.paneedah.mwc.network.messages.OpenCustomPlayerInventoryGuiMessage;
 import com.paneedah.weaponlib.ModContext;
@@ -10,13 +11,14 @@ import net.minecraftforge.fml.client.FMLClientHandler;
 
 import static com.paneedah.mwc.MWC.CHANNEL;
 
+
+/**
+ * The Inventory Tab for accessing your backpack (if present)
+ */
 public class BackpackInventoryTab extends InventoryTab {
 
-    private final ModContext clientModContext;
-
-    public BackpackInventoryTab(ModContext clientModContext) {
+    public BackpackInventoryTab() {
         super(0, 0, 0);
-        this.clientModContext = clientModContext;
     }
 
     @Override

--- a/src/main/java/com/paneedah/mwc/gui/inventory/CustomPlayerInventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/CustomPlayerInventoryTab.java
@@ -23,9 +23,4 @@ public class CustomPlayerInventoryTab extends InventoryTab {
         CHANNEL.sendToServer(new OpenCustomPlayerInventoryGuiMessage(GuiHandler.CUSTOM_PLAYER_INVENTORY_GUI_ID));
 
     }
-
-    @Override
-    public boolean shouldAddToList() {
-        return true;
-    }
 }

--- a/src/main/java/com/paneedah/mwc/gui/inventory/CustomPlayerInventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/CustomPlayerInventoryTab.java
@@ -1,5 +1,6 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui.inventory;
 
+import com.paneedah.mwc.gui.GuiHandler;
 import com.paneedah.mwc.network.messages.OpenCustomPlayerInventoryGuiMessage;
 import com.paneedah.weaponlib.ModContext;
 import net.minecraft.item.Item;
@@ -7,13 +8,14 @@ import net.minecraft.item.ItemStack;
 
 import static com.paneedah.mwc.MWC.CHANNEL;
 
+/**
+ * The Inventory Tab for equipping Vests and Backpacks
+ */
 public class CustomPlayerInventoryTab extends InventoryTab {
 
-    private final ModContext clientModContext;
 
-    public CustomPlayerInventoryTab(ModContext clientModContext, Item tabIconItem) {
+    public CustomPlayerInventoryTab(Item tabIconItem) {
         super(0, 0, 0, new ItemStack(tabIconItem));
-        this.clientModContext = clientModContext;
     }
 
     @Override

--- a/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTab.java
@@ -1,4 +1,4 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui.inventory;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
@@ -10,9 +10,7 @@ import org.lwjgl.opengl.GL12;
 
 public class InventoryTab extends GuiButton {
     private final ResourceLocation texture = new ResourceLocation("textures/gui/container/creative_inventory/tabs.png");
-    //private ItemStack renderStack;
     private ItemStack itemStack;
-    private RenderItem itemRenderer;
 
     public InventoryTab(int id, int posX, int posY, ItemStack itemStack) {
         super(id, posX, posY, 28, 32, "");
@@ -40,19 +38,19 @@ public class InventoryTab extends GuiButton {
             MC.renderEngine.bindTexture(this.texture);
             this.drawTexturedModalRect(this.x, yPos, xOffset * 28, yTexPos, 28, ySize);
 
-            itemRenderer = MC.getRenderItem();
+            RenderItem itemRenderer = MC.getRenderItem();
 
             RenderHelper.enableGUIStandardItemLighting();
             this.zLevel = 100.0F;
-            this.itemRenderer.zLevel = 100.0F;
+            itemRenderer.zLevel = 100.0F;
             GlStateManager.enableLighting();
             GlStateManager.enableRescaleNormal();
             final ItemStack itemStack = getItemStack();
-            this.itemRenderer.renderItemAndEffectIntoGUI(itemStack, x + 6, y + 8);
-            this.itemRenderer.renderItemOverlays(MC.fontRenderer, itemStack, x + 6, y + 8);
+            itemRenderer.renderItemAndEffectIntoGUI(itemStack, x + 6, y + 8);
+            itemRenderer.renderItemOverlays(MC.fontRenderer, itemStack, x + 6, y + 8);
             GlStateManager.disableLighting();
             GlStateManager.enableBlend();
-            this.itemRenderer.zLevel = 0.0F;
+            itemRenderer.zLevel = 0.0F;
             this.zLevel = 0.0F;
             RenderHelper.disableStandardItemLighting();
         }

--- a/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTab.java
@@ -72,6 +72,6 @@ public class InventoryTab extends GuiButton {
     }
 
     public boolean shouldAddToList() {
-        return false;
+        return true;
     }
 }

--- a/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTabHandler.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/InventoryTabHandler.java
@@ -1,4 +1,4 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui.inventory;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiInventory;
@@ -13,15 +13,15 @@ import java.util.List;
 
 import static com.paneedah.mwc.proxies.ClientProxy.MC;
 
-public class InventoryTabs {
+public class InventoryTabHandler {
 
     private final ArrayList<InventoryTab> tabList = new ArrayList<InventoryTab>();
 
-    private static final InventoryTabs instance = new InventoryTabs();
+    private static final InventoryTabHandler instance = new InventoryTabHandler();
 
-    private InventoryTabs() {}
+    private InventoryTabHandler() {}
 
-    public static InventoryTabs getInstance() {
+    public static InventoryTabHandler getInstance() {
         return instance;
     }
 

--- a/src/main/java/com/paneedah/mwc/gui/inventory/StandardPlayerInventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/StandardPlayerInventoryTab.java
@@ -15,9 +15,4 @@ public class StandardPlayerInventoryTab extends InventoryTab {
     public void onTabClicked() {
         InventoryTabHandler.getInstance().openInventoryGui();
     }
-
-    @Override
-    public boolean shouldAddToList() {
-        return true;
-    }
 }

--- a/src/main/java/com/paneedah/mwc/gui/inventory/StandardPlayerInventoryTab.java
+++ b/src/main/java/com/paneedah/mwc/gui/inventory/StandardPlayerInventoryTab.java
@@ -1,8 +1,11 @@
-package com.paneedah.weaponlib.inventory;
+package com.paneedah.mwc.gui.inventory;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
+/**
+ * The default Minecraft Inventory as one of our tabs
+ */
 public class StandardPlayerInventoryTab extends InventoryTab {
     public StandardPlayerInventoryTab() {
         super(0, 0, 0, new ItemStack(Blocks.CRAFTING_TABLE));
@@ -10,7 +13,7 @@ public class StandardPlayerInventoryTab extends InventoryTab {
 
     @Override
     public void onTabClicked() {
-        InventoryTabs.getInstance().openInventoryGui();
+        InventoryTabHandler.getInstance().openInventoryGui();
     }
 
     @Override

--- a/src/main/java/com/paneedah/mwc/proxies/ClientProxy.java
+++ b/src/main/java/com/paneedah/mwc/proxies/ClientProxy.java
@@ -11,10 +11,10 @@ import com.paneedah.weaponlib.crafting.ammopress.TileEntityAmmoPress;
 import com.paneedah.weaponlib.crafting.ammopress.model.AmmoPress;
 import com.paneedah.weaponlib.crafting.workbench.TESRWorkbench;
 import com.paneedah.weaponlib.crafting.workbench.TileEntityWorkbench;
-import com.paneedah.weaponlib.inventory.BackpackInventoryTab;
-import com.paneedah.weaponlib.inventory.CustomPlayerInventoryTab;
-import com.paneedah.weaponlib.inventory.InventoryTabs;
-import com.paneedah.weaponlib.inventory.StandardPlayerInventoryTab;
+import com.paneedah.mwc.gui.inventory.BackpackInventoryTab;
+import com.paneedah.mwc.gui.inventory.CustomPlayerInventoryTab;
+import com.paneedah.mwc.gui.inventory.InventoryTabHandler;
+import com.paneedah.mwc.gui.inventory.StandardPlayerInventoryTab;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -40,11 +40,11 @@ public class ClientProxy extends CommonProxy {
     public void preInit(final MWC mod) {
         super.preInit(mod);
 
-        final InventoryTabs inventoryTabs = InventoryTabs.getInstance();
+        final InventoryTabHandler inventoryTabHandler = InventoryTabHandler.getInstance();
 
-        inventoryTabs.registerTab(new StandardPlayerInventoryTab());
-        inventoryTabs.registerTab(new CustomPlayerInventoryTab(MWC.modContext, MWCItems.vestRender));
-        inventoryTabs.registerTab(new BackpackInventoryTab(MWC.modContext));
+        inventoryTabHandler.registerTab(new StandardPlayerInventoryTab());
+        inventoryTabHandler.registerTab(new CustomPlayerInventoryTab(MWCItems.vestRender));
+        inventoryTabHandler.registerTab(new BackpackInventoryTab());
 
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityWorkbench.class, new TESRWorkbench(new Workbench(), new ResourceLocation(ID + ":textures/blocks/workbench.png")));
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityAmmoPress.class, new TESRAmmoPress(new AmmoPress(), new ResourceLocation(ID + ":textures/blocks/ammo_press.png")));

--- a/src/main/java/com/paneedah/weaponlib/ClientModContext.java
+++ b/src/main/java/com/paneedah/weaponlib/ClientModContext.java
@@ -10,7 +10,7 @@ import com.paneedah.weaponlib.crafting.workbench.GUIContainerWorkbench;
 import com.paneedah.weaponlib.electronics.EntityWirelessCamera;
 import com.paneedah.weaponlib.electronics.WirelessCameraRenderer;
 import com.paneedah.weaponlib.grenade.*;
-import com.paneedah.weaponlib.inventory.InventoryTabs;
+import com.paneedah.mwc.gui.inventory.InventoryTabHandler;
 import com.paneedah.weaponlib.melee.ItemMelee;
 import com.paneedah.weaponlib.melee.MeleeRenderer;
 import com.paneedah.weaponlib.melee.PlayerMeleeInstance;
@@ -74,7 +74,7 @@ public class ClientModContext extends CommonModContext {
         clientEventHandler = new ClientEventHandler(this);
         MinecraftForge.EVENT_BUS.register(clientEventHandler);
 
-        MinecraftForge.EVENT_BUS.register(InventoryTabs.getInstance());
+        MinecraftForge.EVENT_BUS.register(InventoryTabHandler.getInstance());
 
         MinecraftForge.EVENT_BUS.register(clientEventHandler); // TODO: what are the implications of registering the same class with 2 buses
 

--- a/src/main/java/com/paneedah/weaponlib/CommonModContext.java
+++ b/src/main/java/com/paneedah/weaponlib/CommonModContext.java
@@ -17,7 +17,7 @@ import com.paneedah.weaponlib.crafting.workbench.TileEntityWorkbench;
 import com.paneedah.weaponlib.crafting.workbench.WorkbenchBlock;
 import com.paneedah.weaponlib.electronics.*;
 import com.paneedah.weaponlib.grenade.*;
-import com.paneedah.weaponlib.inventory.GuiHandler;
+import com.paneedah.mwc.gui.GuiHandler;
 import com.paneedah.weaponlib.melee.*;
 import com.paneedah.weaponlib.state.StateManager;
 import lombok.Getter;

--- a/src/main/java/com/paneedah/weaponlib/WeaponKeyInputHandler.java
+++ b/src/main/java/com/paneedah/weaponlib/WeaponKeyInputHandler.java
@@ -9,7 +9,7 @@ import com.paneedah.weaponlib.animation.gui.AnimationModeProcessor;
 import com.paneedah.weaponlib.animation.DebugPositioner;
 import com.paneedah.weaponlib.animation.OpenGLSelectionHelper;
 import com.paneedah.mwc.instancing.PlayerTabletInstance;
-import com.paneedah.weaponlib.inventory.GuiHandler;
+import com.paneedah.mwc.gui.GuiHandler;
 import com.paneedah.weaponlib.render.gui.ModificationGUI;
 import net.minecraft.block.BlockDoor;
 import net.minecraft.block.state.IBlockState;

--- a/src/main/java/com/paneedah/weaponlib/crafting/ammopress/BlockAmmoPress.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/ammopress/BlockAmmoPress.java
@@ -3,7 +3,7 @@ package com.paneedah.weaponlib.crafting.ammopress;
 import com.paneedah.mwc.network.messages.CraftingStationClientMessage;
 import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.crafting.base.BlockStation;
-import com.paneedah.weaponlib.inventory.GuiHandler;
+import com.paneedah.mwc.gui.GuiHandler;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;

--- a/src/main/java/com/paneedah/weaponlib/crafting/workbench/WorkbenchBlock.java
+++ b/src/main/java/com/paneedah/weaponlib/crafting/workbench/WorkbenchBlock.java
@@ -3,7 +3,7 @@ package com.paneedah.weaponlib.crafting.workbench;
 import com.paneedah.mwc.network.messages.CraftingStationClientMessage;
 import com.paneedah.weaponlib.ModContext;
 import com.paneedah.weaponlib.crafting.base.BlockStation;
-import com.paneedah.weaponlib.inventory.GuiHandler;
+import com.paneedah.mwc.gui.GuiHandler;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;


### PR DESCRIPTION
## 📝 Description

Extracts the InventoryTab's from weaponlib and improves javadoc 

## 🎯 Goals

* Move InventoryTab's out of weaponlib
* Make the system easier to understand

## ❌ Non Goals

* Mod compatibility
* Large sweeping changes

## 🚦 Testing 

Launch singleplayer, equip backpack, add item to backpack, save and reload to make sure its still there

## ⏮️ Backwards Compatibility 

Yes

## 📚 Related Issues & Documents

N/a

## 🖼️ Screenshots/Recordings

<img width="854" height="480" alt="2026-02-11_20 29 24" src="https://github.com/user-attachments/assets/84317251-0f0e-4f9f-bc96-b6a1786c5f94" />
<img width="854" height="480" alt="2026-02-11_20 29 55" src="https://github.com/user-attachments/assets/89c1ec0c-438d-444d-a068-f574e9b35fa2" />


## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed